### PR TITLE
Fix #35: TTL and time are inverted on Windows

### DIFF
--- a/dart_ping/lib/src/models/ping_parser.dart
+++ b/dart_ping/lib/src/models/ping_parser.dart
@@ -45,8 +45,7 @@ class PingParser {
   RegExp? errorStr;
 
   // ignore: long-method
-  StreamTransformer<String, PingData> get responseParser =>
-      StreamTransformer<String, PingData>.fromHandlers(
+  StreamTransformer<String, PingData> get responseParser => StreamTransformer<String, PingData>.fromHandlers(
         handleData: (data, sink) {
           // Timeout
           if (sequenceRgx != null && data.contains(timeoutStr)) {
@@ -54,7 +53,7 @@ class PingParser {
             if (match == null) {
               return;
             }
-            var seq = match.group(1);
+            var seq = match.namedGroup('seq');
             sink.add(
               PingData(
                 response: PingResponse(
@@ -71,13 +70,13 @@ class PingParser {
             if (match == null) {
               return;
             }
-            var seq = match.group(2);
-            var ttl = match.group(3);
-            var time = match.group(4);
+            var seq = match.groupNames.contains('seq') ? match.namedGroup('seq') : null;
+            var ttl = match.namedGroup('ttl');
+            var time = match.namedGroup('time');
             sink.add(
               PingData(
                 response: PingResponse(
-                  ip: match.group(1),
+                  ip: match.namedGroup('ip'),
                   seq: seq?.isEmpty ?? true ? null : int.parse(seq!),
                   ttl: ttl == null ? null : int.parse(ttl),
                   time: time == null
@@ -93,11 +92,11 @@ class PingParser {
           // Summary
           if (data.contains(summaryStr)) {
             final match = summaryRgx.firstMatch(data);
-            var tx = match?.group(1);
-            var rx = match?.group(2);
+            var tx = match?.namedGroup('tx');
+            var rx = match?.namedGroup('rx');
             String? time;
             if ((match?.groupCount ?? 0) > 2) {
-              time = match?.group(3);
+              time = match?.namedGroup('time');
             }
             if (tx == null || rx == null) {
               return;
@@ -107,9 +106,7 @@ class PingParser {
                 summary: PingSummary(
                   transmitted: int.parse(tx),
                   received: int.parse(rx),
-                  time: time == null
-                      ? null
-                      : Duration(milliseconds: int.parse(time)),
+                  time: time == null ? null : Duration(milliseconds: int.parse(time)),
                 ),
               ),
             );

--- a/dart_ping/lib/src/ping/linux_ping.dart
+++ b/dart_ping/lib/src/ping/linux_ping.dart
@@ -26,15 +26,12 @@ class PingLinux extends BasePing implements Ping {
 
   static PingParser get _parser => PingParser(
         responseStr: RegExp(r'bytes from'),
-        responseRgx:
-            RegExp(r'from (.*): icmp_seq=(\d+) ttl=(\d+) time=((\d+).?(\d+))'),
-        sequenceRgx: RegExp(r'icmp_seq=(\d+)'),
+        responseRgx: RegExp(r'from (?<ip>.*): icmp_seq=(?<seq>\d+) ttl=(?<ttl>\d+) time=(?<time>(\d+).?(\d+))'),
+        sequenceRgx: RegExp(r'icmp_seq=(?<seq>\d+)'),
         summaryStr: RegExp(r'packet loss'),
-        summaryRgx:
-            RegExp(r'(\d+) packets transmitted, (\d+) received,.*time (\d+)ms'),
+        summaryRgx: RegExp(r'(?<tx>\d+) packets transmitted, (?<rx>\d+) received,.*time (?<time>\d+)ms'),
         timeoutStr: RegExp(r'no answer yet'),
-        unknownHostStr:
-            RegExp(r'unknown host|service not known|failure in name'),
+        unknownHostStr: RegExp(r'unknown host|service not known|failure in name'),
       );
 
   @override
@@ -55,8 +52,6 @@ class PingLinux extends BasePing implements Ping {
 
   @override
   Exception? throwExit(int exitCode) {
-    return exitCode > 1
-        ? Exception('Ping process exited with code: $exitCode')
-        : null;
+    return exitCode > 1 ? Exception('Ping process exited with code: $exitCode') : null;
   }
 }

--- a/dart_ping/lib/src/ping/mac_ping.dart
+++ b/dart_ping/lib/src/ping/mac_ping.dart
@@ -26,12 +26,10 @@ class PingMac extends BasePing implements Ping {
 
   static PingParser get _parser => PingParser(
         responseStr: RegExp(r'bytes from'),
-        responseRgx:
-            RegExp(r'from (.*): icmp_seq=(\d+) ttl=(\d+) time=((\d+).?(\d+))'),
-        sequenceRgx: RegExp(r'icmp_seq (\d+)'),
+        responseRgx: RegExp(r'from (.*): icmp_seq=(?<seq>\d+) ttl=(?<ttl>\d+) time=(?<time>(\d+).?(\d+))'),
+        sequenceRgx: RegExp(r'icmp_seq (?<seq>\d+)'),
         summaryStr: RegExp(r'packet loss'),
-        summaryRgx:
-            RegExp(r'(\d+) packets transmitted, (\d+) packets received'),
+        summaryRgx: RegExp(r'(?<tx>\d+) packets transmitted, (?<rx>\d+) packets received'),
         timeoutStr: RegExp(r'Request timeout'),
         unknownHostStr: RegExp(r'Unknown host'),
       );

--- a/dart_ping/lib/src/ping/windows_ping.dart
+++ b/dart_ping/lib/src/ping/windows_ping.dart
@@ -26,9 +26,9 @@ class PingWindows extends BasePing implements Ping {
 
   static PingParser get _parser => PingParser(
         responseStr: RegExp(r'Reply from'),
-        responseRgx: RegExp(r'from (.*): bytes=\d+() time=(\d+)ms TTL=(\d+)'),
+        responseRgx: RegExp(r'from (?<ip>.*): bytes=(?:\d+) time(?:=|<)(?<time>\d+)ms TTL=(?<ttl>\d+)'),
         summaryStr: RegExp(r'Lost'),
-        summaryRgx: RegExp(r'Sent = (\d+), Received = (\d+), Lost = (\d+)'),
+        summaryRgx: RegExp(r'Sent = (?<tx>\d+), Received = (?<rx>\d+), Lost = (?:\d+)'),
         timeoutStr: RegExp(r'host unreachable|timed out'),
         unknownHostStr: RegExp(r'could not find host'),
         errorStr: RegExp(r'transmit failed'),
@@ -63,6 +63,5 @@ class PingWindows extends BasePing implements Ping {
       );
 
   @override
-  Exception throwExit(int exitCode) =>
-      Exception('Ping process exited with code: $exitCode');
+  Exception throwExit(int exitCode) => Exception('Ping process exited with code: $exitCode');
 }


### PR DESCRIPTION
The `time` and `TTL` capture groups were in the wrong order for Windows ping output.  I converted the regex capture groups to named groups and also updated the regex to capture the Windows `time<1ms` output.

ping_parser.dart:
```dart
            var seq = match.groupNames.contains('seq') 
              ? match.namedGroup('seq') 
              : null;
            var ttl = match.namedGroup('ttl');
            var time = match.namedGroup('time');
            sink.add(
              PingData(
                response: PingResponse(
                  ip: match.namedGroup('ip'),
```
```dart
          // Summary
          if (data.contains(summaryStr)) {
            final match = summaryRgx.firstMatch(data);
            var tx = match?.namedGroup('tx');
            var rx = match?.namedGroup('rx');
            String? time;
            if ((match?.groupCount ?? 0) > 2) {
              time = match?.namedGroup('time');
            }
```
windows_ping.dart:
```dart
        responseStr: RegExp(r'Reply from'),
        responseRgx: RegExp(r'from (?<ip>.*): bytes=(?:\d+) time(?:=|<)(?<time>\d+)ms TTL=(?<ttl>\d+)'),
        summaryStr: RegExp(r'Lost'),
        summaryRgx: RegExp(r'Sent = (?<tx>\d+), Received = (?<rx>\d+), Lost = (?:\d+)'),
```
Ping command output:
```
Pinging 127.0.0.1 with 32 bytes of data:
Reply from 127.0.0.1: bytes=32 time<1ms TTL=128
```

Console output:
```
Pinging 127.0.0.1
PingResponse(seq:null, ip:127.0.0.1, ttl:128, time:1.0 ms)
PingSummary(transmitted:1, received:1)
```