### PR TITLE
Add flutter sdk to dart_ping_ios pubspec

### DIFF
--- a/dart_ping_ios/pubspec.yaml
+++ b/dart_ping_ios/pubspec.yaml
@@ -8,6 +8,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
+  flutter:
+    sdk: flutter
   dart_ping: ^9.0.0
   flutter_icmp_ping: ^3.1.2
 


### PR DESCRIPTION
Pub.dev is unable to detect platforms for dart_ping_ios but can do for flutter_icmp_ping. Reason missing flutter sdk dependency