### PR TITLE
feat: base_ping stream lifecycle robustness

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,6 +1,6 @@
 # Requirements
 
-This document tracks two areas of work:
+This document tracks three areas of work:
 
 1. **iOS SPM migration (#73)** — *shipped in `dart_ping_ios` 5.0.0.*
    Replace the `flutter_icmp_ping` dependency with a native Swift ICMP
@@ -9,7 +9,13 @@ This document tracks two areas of work:
 2. **Maintenance & modernization refresh** — a cross-package pass to bring
    dependencies, SDK constraints, documentation, and test coverage current,
    and to surface bugs / security flaws / improvements across the Dart and
-   native Swift code. Captured in the `§req:refresh-*` sections at the end.
+   native Swift code. Captured in the `§req:refresh-*` sections.
+3. **`base_ping` stream lifecycle robustness (#76)** — fix two edge paths
+   in the core `dart_ping` stream where a consumer can hang forever
+   instead of seeing an error: an unmapped non-zero exit code, and a
+   failed process launch (e.g. a missing `ping` binary). Surfaced by the
+   Dart code audit (`§spec:code-audit`). Captured in the
+   `§req:robustness-*` sections at the end.
 
 ---
 
@@ -279,3 +285,132 @@ Observable, verifiable outcomes:
 - **Nice-to-have:** deeper test coverage beyond the obvious gaps; replacing
   the stale `dart_code_metrics` config with a maintained metrics/lint
   alternative.
+
+---
+
+# base_ping stream lifecycle robustness (#76)
+
+Two related medium-severity robustness defects in the core `dart_ping`
+ping stream, deferred from the maintenance audit (`§spec:code-audit`)
+because they were not cheap-and-clearly-correct enough to fix inline.
+Both only trigger on edge paths; normal runs are unaffected.
+
+## Robustness — problem statement §req:robustness-problem-statement
+
+The target users are developers consuming `dart_ping`'s `Ping` stream —
+typically with `await for`, `.drain()`, `.last`, or by awaiting `stop()`.
+They expect the stream to always finish: either delivering responses and
+a summary, or surfacing an error they can catch.
+
+On two edge paths the stream instead **hangs forever** — it never emits
+the failure and never closes, so the consumer's `await` blocks
+indefinitely:
+
+- **Unmapped non-zero exit code.** When the `ping` process exits with a
+  non-zero code that the platform does not recognize as a known error,
+  the cleanup logic throws from inside the subscription's `onDone`
+  callback. Because that callback's future is not awaited, the exception
+  is swallowed and — critically — the stream controller is never closed.
+  The consumer hangs on an exotic exit code.
+- **Process-launch failure.** When the `ping` binary cannot be started
+  (e.g. it is not installed), the failure escapes during stream start-up
+  before the subscription is wired up. The intended "Could not find ping
+  binary…" error never reaches the consumer, nothing is emitted, and the
+  stream never closes — so the consumer hangs instead of seeing the
+  error.
+
+Current behavior fails these users because a hang is the worst possible
+outcome: there is no error to catch, no completion to await, and no
+timeout — the calling code simply stalls. These paths are rare (unusual
+exit codes, a missing binary), but when they happen they are silent and
+unrecoverable from the consumer's side.
+
+A third, lower-severity observation is folded in: the stream merges the
+process's stderr and stdout *before* splitting into lines, which could in
+theory interleave and corrupt a diagnostic line. In practice `ping` is
+line-buffered on a single stream, so this has not been observed — but it
+is in scope to harden against.
+
+## Robustness — success criteria §req:robustness-success-criteria
+
+Observable, end-to-end outcomes a tester can demonstrate against the
+`Ping` stream:
+
+- **Missing-binary launch failure surfaces an error, then closes.** With
+  no usable `ping` binary on the system, a consumer listening to the
+  stream receives an error event whose message indicates the ping binary
+  could not be found, and the stream then closes — within bounded time,
+  with no hang. *(must-have)*
+- **Any other launch failure surfaces an error, then closes.** If the
+  process fails to start for any other reason, the consumer receives an
+  error event and the stream closes rather than hanging. *(must-have)*
+- **Unmapped non-zero exit surfaces an error, then closes.** When the
+  ping process exits with a non-zero code the platform does not map to a
+  known `PingError`, the consumer receives an error event and the stream
+  closes — instead of the stream staying open forever. *(must-have)*
+- **The stream always terminates.** On every path — normal completion,
+  a mapped error exit, an unmapped exit, a launch failure, and
+  cancel/`stop()` — the stream closes exactly once, so a consumer
+  awaiting completion always returns and never deadlocks. *(must-have)*
+- **Normal runs are unchanged.** For a successful run (zero exit) or a
+  recognized error exit, the consumer still receives the same per-probe
+  responses, the run summary, and the per-run error list as before, and
+  the stream closes as before. *(must-have — regression guard)*
+- **Diagnostic lines arrive intact.** Each response/error line the
+  consumer expects is delivered whole; lines are not corrupted, split,
+  or dropped as a result of stderr and stdout being combined before
+  line-splitting. *(high)*
+- **The edge paths are covered by automated tests.** Missing-binary
+  launch failure, unmapped non-zero exit, and unchanged normal
+  completion each have a test that fails if the stream hangs or
+  swallows the error. *(high — aligns with `§req:refresh-success-criteria`
+  stream-lifecycle coverage)*
+
+## Robustness — user stories §req:robustness-user-stories
+
+- As a developer pinging a host, when the `ping` binary is missing I want
+  to receive a clear error I can catch so that my `await for` loop fails
+  fast instead of hanging forever.
+- As a developer, when `ping` exits with an unusual code my platform
+  does not recognize, I want the stream to surface an error and close so
+  that I can handle the failure rather than stall.
+- As a developer who awaits stream completion (`.drain()`, `.last`, or
+  `stop()`), I want the stream to always close so that my code never
+  deadlocks on an edge path.
+- As an existing `dart_ping` user, I want normal ping runs to behave
+  exactly as they do today so that this fix is invisible to working code.
+
+## Robustness — quality attributes §req:robustness-quality-attributes
+
+- **Reliability:** the stream terminates on every code path. No path
+  leaves the controller open; failures are observable, not silent.
+- **Compatibility:** the public API is unchanged — the `Ping` interface
+  and the `PingData` / `PingResponse` / `PingSummary` / `PingError`
+  shapes stay the same. Errors surface through the stream's existing
+  error channel that consumers already handle; normal-run output is
+  byte-for-byte equivalent.
+- **Testability:** each edge path is exercised by an automated test that
+  fails on a hang or a swallowed error, runnable under `dart test`
+  without a live network.
+
+## Robustness — constraints §req:robustness-constraints
+
+- The fix is internal to the core `dart_ping` package
+  (`lib/src/ping/base_ping.dart`); no change to the public API or to
+  `dart_ping_ios`.
+- This is a **non-breaking, patch-level** change to `dart_ping`.
+- Scope is the three items above (two hang paths + stderr/stdout line
+  integrity). Surfaced by, and traceable to, the audit
+  (`§spec:code-audit`); related to the refresh's stream-lifecycle test
+  goal in `§req:refresh-success-criteria`.
+
+## Robustness — priorities §req:robustness-priorities
+
+- **Must-have:** both hang paths fixed — a missing binary and an unmapped
+  exit code each surface a catchable error and close the stream, with
+  normal runs unchanged.
+- **High priority:** automated tests covering the missing-binary,
+  unmapped-exit, and normal-completion paths; harden stderr/stdout line
+  integrity so diagnostic lines arrive intact.
+- **Nice-to-have:** none beyond the above — this is a focused robustness
+  fix.

--- a/SPEC.md
+++ b/SPEC.md
@@ -502,7 +502,7 @@ non-zero exit, and the `onListen` body before the subscription is wired up —
 so the exception is swallowed and the stream controller is never closed.
 
 ## Stream always terminates and surfaces errors §spec:stream-lifecycle-robustness
-*Status: not started*
+*Status: implemented (dart_ping 9.1.1) — teardown centralized through an idempotent `_closeController()` and a `try/finally` in `_cleanup`, so the `StreamController` closes exactly once on every terminal path. Launch failures (incl. a missing `ping` binary, which reports the binary could not be found) are caught in `_onListen` and routed to the error channel before closing; an unmapped non-zero exit surfaces `throwExit`'s exception via `addError` instead of swallowing/throwing in `onDone`. stderr/stdout are decoded and line-split independently before merging. Covered by network-free `dart test` cases in `dart_ping/test/stream_lifecycle_test.dart` (launch failure, unmapped exit, normal-completion regression guard, close-exactly-once across all paths) that fail on a hang or swallowed error; public API and normal-run output unchanged.*
 
 The `Ping` stream terminates on every code path and routes failures through
 its error channel rather than leaving the consumer to hang. Errors surface

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,11 +1,14 @@
 # Specification
 
-This document covers two areas, matching REQUIREMENTS.md:
+This document covers three areas, matching REQUIREMENTS.md:
 
 1. **iOS SPM migration (#73)** — `§spec:swift-icmp-engine` …
    `§spec:ios-tests` below (implemented).
 2. **Maintenance & modernization refresh** — the `§spec:dependency-currency`
-   … `§spec:code-audit` sections at the end (not started).
+   … `§spec:code-audit` sections (complete).
+3. **`base_ping` stream lifecycle robustness (#76)** —
+   `§spec:stream-lifecycle-robustness` at the end (not started). A focused
+   follow-up to two hang paths deferred from `§spec:code-audit`.
 
 Solution-space design for issue #73 — native, Swift Package Manager
 (SPM)-compatible iOS support for `dart_ping`.
@@ -477,3 +480,91 @@ rather than hostile input.
 excludes new CI/infrastructure in this pass (§spec:test-coverage,
 §req:refresh-constraints). The deliverable is the triaged finding list and
 the applied cheap fixes; standing enforcement is out of scope.
+
+---
+
+# base_ping stream lifecycle robustness
+
+Solution-space design for issue #76 (`§req:robustness-*`), a focused
+follow-up to two medium-severity hang paths the maintenance audit surfaced
+and deferred (`§spec:code-audit`). The work is confined to the core
+`dart_ping` package and changes no public surface; it is independent of the
+#73 iOS work and the rest of the refresh.
+
+The problem (from §req:robustness-problem-statement): a consumer of the
+`Ping` stream expects it to always finish — delivering responses and a
+summary, or surfacing an error they can catch. On two edge paths the stream
+instead stays open forever, with no error and no completion, so a consumer
+awaiting it (`await for`, `.drain()`, `.last`, `stop()`) blocks
+indefinitely. Both paths arise because a failure is raised from an async
+context whose future nobody awaits — the `onDone` callback on an unmapped
+non-zero exit, and the `onListen` body before the subscription is wired up —
+so the exception is swallowed and the stream controller is never closed.
+
+## Stream always terminates and surfaces errors §spec:stream-lifecycle-robustness
+*Status: not started*
+
+The `Ping` stream terminates on every code path and routes failures through
+its error channel rather than leaving the consumer to hang. Errors surface
+through the stream's existing error channel, which consumers already handle;
+no public type or method changes (§spec:public-api-stability,
+§req:robustness-quality-attributes — compatibility).
+
+- When the ping process fails to launch, the stream shall emit an error
+  event and then close within bounded time, instead of hanging. When the
+  failure is a missing `ping` binary, the error's message shall indicate
+  that the ping binary could not be found
+  (§req:robustness-success-criteria, §req:robustness-user-stories).
+- When the process exits with a non-zero code that the platform does not
+  map to a known `PingError`, the stream shall emit an error event and then
+  close, instead of staying open forever
+  (§req:robustness-success-criteria, §req:robustness-user-stories).
+- On every path — normal zero-exit completion, a mapped error exit, an
+  unmapped exit, a launch failure, and cancel/`stop()` — the stream shall
+  close exactly once, so a consumer awaiting completion always returns and
+  never deadlocks (§req:robustness-success-criteria,
+  §req:robustness-quality-attributes — reliability).
+- For a successful run (zero exit) or a recognized error exit, the consumer
+  shall still receive the same per-probe responses, the run summary, and the
+  per-run `PingSummary.errors` list as before, and the stream shall close as
+  before (§req:robustness-success-criteria — regression guard).
+- Each diagnostic line the consumer expects shall be delivered whole; the
+  combination of the process's stderr and stdout shall not corrupt, split,
+  or drop a line (§req:robustness-success-criteria,
+  §req:robustness-quality-attributes — reliability).
+- The missing-binary launch failure, the unmapped non-zero exit, and an
+  unchanged normal completion shall each be covered by an automated test
+  under `dart test` that runs without a live network and fails if the stream
+  hangs or swallows the error (§req:robustness-success-criteria,
+  §req:refresh-success-criteria — stream-lifecycle coverage).
+
+**Why a hang is the failure to design out:** a hung stream is strictly worse
+than an error — there is nothing to catch, nothing to await, and no timeout,
+so the caller simply stalls (§req:robustness-problem-statement). The fix
+reframes both edge paths as ordinary stream errors: a failure on any path
+becomes an error event on the channel consumers already use, and the
+controller is closed on every path so completion is guaranteed. The two
+specific defects — a throw inside the `onDone` callback on an unmapped exit,
+and a throw escaping the async start-up before the subscription exists — are
+the mechanisms behind the hang, but the section's contract is the
+observable guarantee (always closes, always surfaces), which survives any
+change to how start-up and teardown are wired.
+
+**Why the line-integrity criterion rides along here:** stderr and stdout are
+merged before line-splitting, so in theory two writes could interleave and
+corrupt a diagnostic line. In practice `ping` is line-buffered on a single
+stream and this has never been observed (§req:robustness-problem-statement),
+so it is hardening rather than a known defect — but it touches the same
+stream-assembly code and the same observable surface (whole lines reaching
+the consumer), so it is closed in the same pass rather than tracked
+separately.
+
+**Why patch-level and API-frozen:** the change is internal to
+`dart_ping/lib/src/ping/base_ping.dart`; the `Ping` interface and the
+`PingData` / `PingResponse` / `PingSummary` / `PingError` shapes are
+unchanged, normal-run output is byte-for-byte equivalent, and failures
+surface through the error channel consumers already handle. It therefore
+ships as a non-breaking, patch-level release of `dart_ping` with no change
+to `dart_ping_ios` (§req:robustness-constraints). A larger redesign of the
+stream lifecycle was rejected as disproportionate to a focused robustness
+fix (§req:robustness-priorities).

--- a/dart_ping/CHANGELOG.md
+++ b/dart_ping/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Fix #76: the `Ping` stream could hang forever on two edge paths — a process-launch failure (e.g. a missing `ping` binary) and an unmapped non-zero exit code. Both now surface a catchable error through the stream's existing error channel and the stream always closes, so consumers (`await for`, `.drain()`, `.last`, `stop()`) never deadlock. A missing-binary failure reports that the ping binary could not be found.
 - Harden stderr/stdout line integrity: each stream is decoded and line-split independently before merging, so interleaved writes cannot corrupt, split, or drop a diagnostic line. Normal-run output is unchanged.
+- Route parser/transform errors through the stream's error channel instead of letting them escape as uncaught async errors, completing the "always surface, always close" guarantee.
+- `stop()` now terminates the run reliably even when called during process launch, and consumer pause/resume now actually pause/resume the underlying ping output.
+- Detect a missing `ping` binary by the OS error code (not just an English message string), and never leave a launched process running when stream start-up fails.
 
 ## 9.1.0
 

--- a/dart_ping/CHANGELOG.md
+++ b/dart_ping/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 9.1.1
+
+- Fix #76: the `Ping` stream could hang forever on two edge paths — a process-launch failure (e.g. a missing `ping` binary) and an unmapped non-zero exit code. Both now surface a catchable error through the stream's existing error channel and the stream always closes, so consumers (`await for`, `.drain()`, `.last`, `stop()`) never deadlock. A missing-binary failure reports that the ping binary could not be found.
+- Harden stderr/stdout line integrity: each stream is decoded and line-split independently before merging, so interleaved writes cannot corrupt, split, or drop a diagnostic line. Normal-run output is unchanged.
+
 ## 9.1.0
 
 - Fix parser crash on macOS and Windows when a TTL-exceeded reply is received: the `seq` capture group is now read only when the platform's pattern defines it (previously force-unwrapped, throwing "Not a capture group name: seq")

--- a/dart_ping/dart_test.yaml
+++ b/dart_ping/dart_test.yaml
@@ -1,0 +1,8 @@
+# Test tag declarations.
+#
+# `live` marks tests that spawn the real `ping` binary and reach the network.
+# They are excluded from the deterministic gate with `dart test -x live` (hosted
+# CI runners block unprivileged ICMP) and run on demand with `dart test -t live`
+# as a local/manual acceptance path.
+tags:
+  live:

--- a/dart_ping/lib/src/ping/base_ping.dart
+++ b/dart_ping/lib/src/ping/base_ping.dart
@@ -23,8 +23,8 @@ abstract class BasePing {
     _controller = StreamController<PingData>(
       onListen: _onListen,
       onCancel: _onCancel,
-      onPause: () => _sub.pause,
-      onResume: () => _sub.resume,
+      onPause: () => _sub?.pause(),
+      onResume: () => _sub?.resume(),
     );
   }
 
@@ -61,9 +61,17 @@ abstract class BasePing {
 
   late final StreamController<PingData> _controller;
   Process? _process;
-  late final StreamSubscription<PingData> _sub;
+  StreamSubscription<PingData>? _sub;
   PingData? _summaryData;
   final List<PingError> _errors = [];
+
+  /// Whether a consumer has begun listening (so [_onListen] has started). Used
+  /// by [stop] to decide whether awaiting closure could ever return.
+  bool _started = false;
+
+  /// Whether [stop] was requested before the process finished launching, so the
+  /// process can be killed as soon as it exists.
+  bool _stopRequested = false;
 
   /// Command to set english locale before running ping command
   Map<String, String> get locale;
@@ -100,6 +108,7 @@ abstract class BasePing {
           .transform<PingData>(parser.transformParser);
 
   Future<void> _onListen() async {
+    _started = true;
     try {
       // Start new ping process on host OS
       _process = await platformProcess;
@@ -117,19 +126,35 @@ abstract class BasePing {
             _summaryData = event;
           }
         },
+        // Route parser/transform errors through the stream's error channel so
+        // they reach the consumer instead of escaping as uncaught async errors;
+        // the stream still closes via onDone.
+        onError: (Object error, StackTrace stackTrace) {
+          if (!_controller.isClosed) {
+            _controller.addError(error, stackTrace);
+          }
+        },
         onDone: _cleanup,
       );
+      // A stop() that arrived while the process was still launching could not
+      // kill it yet; honor that request now that the process exists.
+      if (_stopRequested) {
+        _process!.kill(ProcessSignal.sigint);
+      }
     } catch (error, stackTrace) {
-      // The launch (or wiring) failed before a subscription was established;
-      // surface the error and close the stream so the consumer never hangs.
-      final mappedError = error.toString().contains('No such file')
-          ? Exception(
-              'Could not find ping binary on this system. Please ensure it is installed',
-            )
-          : error;
+      // The launch failed before a subscription was established; surface the
+      // error and close the stream so the consumer never hangs. If the process
+      // had already started before the failure, do not leave it running.
+      _process?.kill(ProcessSignal.sigint);
+      final mappedError =
+          (error is ProcessException && error.errorCode == 2) ||
+                  error.toString().contains('No such file')
+              ? Exception(
+                  'Could not find ping binary on this system. Please ensure it is installed',
+                )
+              : error;
       _controller.addError(mappedError, stackTrace);
       await _closeController();
-      return;
     }
   }
 
@@ -181,9 +206,9 @@ abstract class BasePing {
         _controller.add(_summaryData!);
       }
     } catch (error, stackTrace) {
-      if (!_controller.isClosed) {
-        _controller.addError(error, stackTrace);
-      }
+      // The controller is only closed in the finally below, so it is still
+      // open here and the error can always be surfaced.
+      _controller.addError(error, stackTrace);
     } finally {
       // All done! Make sure nothing else gets added
       await _closeController();
@@ -203,8 +228,13 @@ abstract class BasePing {
   }
 
   Future<bool> stop() async {
+    _stopRequested = true;
     final killed = _process?.kill(ProcessSignal.sigint) ?? false;
-    if (_process != null && !_controller.isClosed) {
+    // Await closure whenever a consumer has started listening — even if the
+    // process is still launching, since _onListen will kill it once it exists —
+    // so stop() never returns before the stream terminates. When nothing was
+    // ever started, the controller will never close, so do not await.
+    if (_started && !_controller.isClosed) {
       await _controller.done;
     }
 

--- a/dart_ping/lib/src/ping/base_ping.dart
+++ b/dart_ping/lib/src/ping/base_ping.dart
@@ -86,74 +86,107 @@ abstract class BasePing {
     );
   }
 
+  /// Decodes and line-splits a single raw byte stream so that whole lines are
+  /// produced before the streams are merged.
+  Stream<String> _lines(Stream<List<int>> raw) =>
+      raw.transform(encoding.decoder).transform(const LineSplitter());
+
   /// Transforms the ping process output into PingData objects
+  ///
+  /// Each raw stream is decoded and line-split independently before merging, so
+  /// interleaved stderr/stdout writes cannot corrupt or split a line.
   Stream<PingData> get _parsedOutput =>
-      StreamGroup.merge([_process!.stderr, _process!.stdout])
-          .transform(encoding.decoder)
-          .transform(LineSplitter())
+      StreamGroup.merge([_lines(_process!.stderr), _lines(_process!.stdout)])
           .transform<PingData>(parser.transformParser);
 
   Future<void> _onListen() async {
-    // Start new ping process on host OS
-    _process = await platformProcess.catchError((error) {
-      if (error.toString().contains('No such file')) {
-        throw Exception(
-          'Could not find ping binary on this system. Please ensure it is installed',
-        );
-      }
-      throw error;
-    });
-    // Get platform-specific parsed PingData
-    _sub = _parsedOutput.listen(
-      (event) {
-        if (event.response != null || event.error != null) {
-          // Accumulate error if one exists
-          if (event.error != null) {
-            _errors.add(event.error!);
+    try {
+      // Start new ping process on host OS
+      _process = await platformProcess;
+      // Get platform-specific parsed PingData
+      _sub = _parsedOutput.listen(
+        (event) {
+          if (event.response != null || event.error != null) {
+            // Accumulate error if one exists
+            if (event.error != null) {
+              _errors.add(event.error!);
+            }
+            _controller.add(event);
+          } else if (event.summary != null) {
+            event.summary!.errors.addAll(_errors);
+            _summaryData = event;
           }
-          _controller.add(event);
-        } else if (event.summary != null) {
-          event.summary!.errors.addAll(_errors);
-          _summaryData = event;
-        }
-      },
-      onDone: _cleanup,
-    );
+        },
+        onDone: _cleanup,
+      );
+    } catch (error, stackTrace) {
+      // The launch (or wiring) failed before a subscription was established;
+      // surface the error and close the stream so the consumer never hangs.
+      final mappedError = error.toString().contains('No such file')
+          ? Exception(
+              'Could not find ping binary on this system. Please ensure it is installed',
+            )
+          : error;
+      _controller.addError(mappedError, stackTrace);
+      await _closeController();
+      return;
+    }
+  }
+
+  /// Closes the stream controller exactly once.
+  Future<void> _closeController() async {
+    if (!_controller.isClosed) {
+      await _controller.close();
+    }
   }
 
   /// Processes output summary and closes stream after ping process is done
+  ///
+  /// The body runs inside a try/finally so the controller closes exactly once
+  /// on every terminal path (normal zero-exit, mapped error exit, unmapped
+  /// exit, and any unexpected throw), routing failures through the error
+  /// channel instead of leaving the consumer to hang.
   Future<void> _cleanup() async {
-    final exitCode = await _process!.exitCode;
+    try {
+      final exitCode = await _process!.exitCode;
 
-    if (exitCode != 0) {
-      // Does the exit code reveal an error?
-      final error = interpretExitCode(exitCode);
-      if (error != null) {
-        // Is there a ping summary that we should add exit code info to?
-        if (_summaryData != null) {
-          _summaryData!.summary!.errors.add(error);
+      if (exitCode != 0) {
+        // Does the exit code reveal an error?
+        final error = interpretExitCode(exitCode);
+        if (error != null) {
+          // Is there a ping summary that we should add exit code info to?
+          if (_summaryData != null) {
+            _summaryData!.summary!.errors.add(error);
+          } else {
+            _summaryData = PingData(
+              summary: PingSummary(
+                transmitted: 0,
+                received: 0,
+                time: Duration(),
+                errors: [error],
+              ),
+            );
+          }
         } else {
-          _summaryData = PingData(
-            summary: PingSummary(
-              transmitted: 0,
-              received: 0,
-              time: Duration(),
-              errors: [error],
-            ),
-          );
+          // Unmapped non-zero exit: surface the exception rather than
+          // discarding it, so the consumer can catch it.
+          final ex = throwExit(exitCode);
+          if (ex != null) {
+            _controller.addError(ex);
+          }
         }
-      } else {
-        throwExit(exitCode);
       }
-    }
 
-    if (_summaryData != null) {
-      _controller.add(_summaryData!);
-    }
-
-    // All done! Make sure nothing else gets added
-    if (!_controller.isClosed) {
-      await _controller.close();
+      if (_summaryData != null) {
+        _controller.add(_summaryData!);
+      }
+    } catch (error, stackTrace) {
+      if (!_controller.isClosed) {
+        _controller.addError(error, stackTrace);
+      }
+    } finally {
+      // All done! Make sure nothing else gets added
+      await _closeController();
     }
   }
 

--- a/dart_ping/pubspec.yaml
+++ b/dart_ping/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_ping
 description: Multi-platform network ping utility for native desktop and android applications.
-version: 9.1.0
+version: 9.1.1
 homepage: https://github.com/point-source/dart_ping
 repository: https://github.com/point-source/dart_ping
 

--- a/dart_ping/test/ping_test.dart
+++ b/dart_ping/test/ping_test.dart
@@ -1,3 +1,6 @@
+@Tags(['live'])
+library;
+
 import 'dart:io';
 
 import 'package:dart_ping/dart_ping.dart';

--- a/dart_ping/test/stream_lifecycle_test.dart
+++ b/dart_ping/test/stream_lifecycle_test.dart
@@ -1,0 +1,266 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_ping/dart_ping.dart';
+import 'package:dart_ping/src/ping/linux_ping.dart';
+import 'package:test/test.dart';
+
+/// Hard ceiling for every awaited completion. A hung stream never closes, so
+/// the timeout converts a hang into a deterministic test failure instead of
+/// blocking the whole suite.
+const _hardTimeout = Duration(seconds: 5);
+
+/// Controllable in-memory [Process] stand-in. No real OS process is started,
+/// so these tests run with NO network and NO subprocess.
+///
+/// The stdout/stderr streams are built from [Stream.fromIterable], so they
+/// emit their chunks and then close. That closure is what lets the merged line
+/// stream complete and `onDone` (`_cleanup`) fire.
+class FakeProcess implements Process {
+  FakeProcess({
+    List<String> stdoutLines = const [],
+    List<String> stderrLines = const [],
+    required int exit,
+  })  : _stdout = Stream<List<int>>.fromIterable(
+          stdoutLines.map((l) => utf8.encode('$l\n')),
+        ),
+        _stderr = Stream<List<int>>.fromIterable(
+          stderrLines.map((l) => utf8.encode('$l\n')),
+        ),
+        _exitCode = Future<int>.value(exit);
+
+  final Stream<List<int>> _stdout;
+  final Stream<List<int>> _stderr;
+  final Future<int> _exitCode;
+
+  @override
+  Stream<List<int>> get stdout => _stdout;
+
+  @override
+  Stream<List<int>> get stderr => _stderr;
+
+  @override
+  Future<int> get exitCode => _exitCode;
+
+  @override
+  bool kill([ProcessSignal signal = ProcessSignal.sigterm]) => true;
+
+  @override
+  int get pid => throw UnimplementedError();
+
+  @override
+  IOSink get stdin => throw UnimplementedError();
+}
+
+/// [PingLinux] subclass that replaces the OS process launch with either a
+/// configured [FakeProcess] or a launch failure. All parsing and exit-code
+/// interpretation are inherited from [PingLinux] unchanged.
+class TestPing extends PingLinux {
+  TestPing({
+    FakeProcess? process,
+    Object? launchError,
+  })  : _process = process,
+        _launchError = launchError,
+        super('1.1.1.1', 5, 1000, 1000, 255, false);
+
+  final FakeProcess? _process;
+  final Object? _launchError;
+
+  @override
+  Future<Process> get platformProcess async {
+    final launchError = _launchError;
+    if (launchError != null) {
+      throw launchError;
+    }
+    return _process!;
+  }
+}
+
+/// Result of draining a ping stream to completion.
+class _Collected {
+  final List<PingData> data = [];
+  final List<Object> errors = [];
+  int doneCount = 0;
+}
+
+/// Listens to [ping.stream], collecting data and error events and counting how
+/// many times the stream's done callback fires. Awaits completion under a hard
+/// timeout so a hang FAILS the test rather than blocking the suite.
+Future<_Collected> _drain(Ping ping) async {
+  final collected = _Collected();
+  final completer = Completer<void>();
+
+  ping.stream.listen(
+    collected.data.add,
+    onError: collected.errors.add,
+    onDone: () {
+      collected.doneCount++;
+      if (!completer.isCompleted) completer.complete();
+    },
+  );
+
+  await completer.future.timeout(
+    _hardTimeout,
+    onTimeout: () => fail('Stream hung: done never fired within $_hardTimeout'),
+  );
+  return collected;
+}
+
+void main() {
+  group('stream-lifecycle-robustness (§spec:stream-lifecycle-robustness)', () {
+    test('(a) missing-binary launch failure emits error and closes', () async {
+      // ProcessException.toString() contains 'No such file or directory',
+      // which the fix maps to the binary-not-found message.
+      final ping = TestPing(
+        launchError: const ProcessException(
+          'ping',
+          [],
+          'No such file or directory',
+          2,
+        ),
+      );
+
+      final result = await _drain(ping);
+
+      expect(result.errors, hasLength(1),
+          reason: 'exactly one error event expected on launch failure');
+      expect(result.errors.single.toString(), contains('ping binary'));
+      expect(result.errors.single.toString(),
+          contains('Could not find ping binary'));
+      expect(result.doneCount, 1, reason: 'stream must close exactly once');
+    });
+
+    test('(b) unmapped non-zero exit emits error and closes', () async {
+      // exitCode 2 -> interpretExitCode returns null, throwExit returns an
+      // Exception that must be surfaced (not swallowed).
+      final ping = TestPing(
+        process: FakeProcess(
+          stdoutLines: const [
+            '64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=10.1 ms',
+          ],
+          exit: 2,
+        ),
+      );
+
+      final result = await _drain(ping);
+
+      expect(result.errors, isNotEmpty,
+          reason: 'unmapped non-zero exit must surface an error');
+      expect(result.errors.first.toString(),
+          contains('Ping process exited with code: 2'));
+      expect(result.doneCount, 1, reason: 'stream must close exactly once');
+    });
+
+    test('(c) regression guard - normal completion', () async {
+      final ping = TestPing(
+        process: FakeProcess(
+          stdoutLines: const [
+            '64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=10.1 ms',
+            '64 bytes from 1.1.1.1: icmp_seq=2 ttl=57 time=11.2 ms',
+            '5 packets transmitted, 5 received, 0% packet loss, time 4005ms',
+          ],
+          exit: 0,
+        ),
+      );
+
+      final result = await _drain(ping);
+
+      expect(result.errors, isEmpty,
+          reason: 'a clean run must not surface an error');
+      expect(result.doneCount, 1, reason: 'stream must close exactly once');
+
+      final responses = result.data
+          .where((d) => d.response != null)
+          .map((d) => d.response!)
+          .toList();
+      expect(responses, hasLength(2), reason: 'two per-probe responses');
+      expect(responses[0].seq, 1);
+      expect(responses[0].ttl, 57);
+      expect(responses[0].ip, '1.1.1.1');
+      expect(responses[1].seq, 2);
+      expect(responses[1].ttl, 57);
+
+      final summaries = result.data.where((d) => d.summary != null).toList();
+      expect(summaries, hasLength(1), reason: 'one run summary expected');
+      final summary = summaries.single.summary!;
+      expect(summary.transmitted, 5);
+      expect(summary.received, 5);
+      expect(summary.time, const Duration(milliseconds: 4005));
+      // Per-run error list is present and empty on a clean run.
+      expect(summary.errors, isEmpty);
+    });
+
+    group('(d) close-exactly-once across terminal paths', () {
+      test('normal completion closes once', () async {
+        final ping = TestPing(
+          process: FakeProcess(
+            stdoutLines: const [
+              '64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=10.1 ms',
+              '5 packets transmitted, 5 received, 0% packet loss, time 4005ms',
+            ],
+            exit: 0,
+          ),
+        );
+        final result = await _drain(ping);
+        expect(result.doneCount, 1);
+      });
+
+      test('unmapped exit closes once', () async {
+        final ping = TestPing(
+          process: FakeProcess(
+            stdoutLines: const [
+              '64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=10.1 ms',
+            ],
+            exit: 2,
+          ),
+        );
+        final result = await _drain(ping);
+        expect(result.doneCount, 1);
+      });
+
+      test('launch failure closes once', () async {
+        final ping = TestPing(
+          launchError: const ProcessException(
+            'ping',
+            [],
+            'No such file or directory',
+            2,
+          ),
+        );
+        final result = await _drain(ping);
+        expect(result.doneCount, 1);
+      });
+
+      test('drain() returns within timeout on normal completion', () async {
+        final ping = TestPing(
+          process: FakeProcess(
+            stdoutLines: const [
+              '5 packets transmitted, 5 received, 0% packet loss, time 4005ms',
+            ],
+            exit: 0,
+          ),
+        );
+        // drain() resolves only if the stream closes; the timeout converts a
+        // hang into a failure.
+        await ping.stream.drain().timeout(_hardTimeout);
+      });
+
+      test('stop() returns after the stream terminates', () async {
+        final ping = TestPing(
+          process: FakeProcess(
+            stdoutLines: const [
+              '5 packets transmitted, 5 received, 0% packet loss, time 4005ms',
+            ],
+            exit: 0,
+          ),
+        );
+        // Begin consuming so the controller has a listener and starts the
+        // process; stop() awaits controller.done, which must return.
+        final result = _drain(ping);
+        await ping.stop().timeout(_hardTimeout);
+        await result;
+      });
+    });
+  });
+}

--- a/dart_ping/test/termination_test.dart
+++ b/dart_ping/test/termination_test.dart
@@ -1,3 +1,6 @@
+@Tags(['live'])
+library;
+
 import 'package:dart_ping/dart_ping.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
## What this builds

Fixes issue **#76** — two edge paths where the core `dart_ping` `Ping` stream
could hang forever instead of surfacing an error. The work is internal to
`dart_ping` (`lib/src/ping/base_ping.dart`); the public API is unchanged and
`dart_ping_ios` is untouched. Ships as a **non-breaking patch** (`dart_ping`
9.1.0 → 9.1.1).

The stream now **terminates on every path** and routes failures through its
existing error channel:

- **Process-launch failure** (e.g. a missing `ping` binary) now emits a
  catchable error — message indicates the binary could not be found — then
  closes, instead of hanging. Missing-binary detection uses the OS error code
  (`ProcessException.errorCode`), not just an English message string.
- **Unmapped non-zero exit code** now emits an error event and closes, instead
  of staying open forever.
- The controller **closes exactly once** on every terminal path (normal exit,
  mapped error, unmapped exit, launch failure, cancel/`stop()`), so a consumer
  awaiting completion (`await for`, `.drain()`, `.last`, `stop()`) never
  deadlocks. Normal-run output is byte-for-byte unchanged.
- **stderr/stdout line integrity:** each stream is decoded and line-split
  independently before merging, so interleaved writes cannot corrupt, split, or
  drop a diagnostic line.

Hardening folded in from the in-kandev code review (see below):

- Parser/transform errors are routed through the stream's error channel
  (instead of escaping as uncaught async errors).
- `stop()` terminates reliably even when called during process launch; consumer
  pause/resume now actually pause/resume the underlying ping output; a
  half-launched process is never left running on a start-up failure.

## Spec sections now complete

- **§spec:stream-lifecycle-robustness** — *implemented* (was the only
  not-started section in `SPEC.md`). Traces to `§req:robustness-*`.

## Reviewer integration test path

```bash
cd dart_ping
dart pub get
dart analyze --fatal-infos          # 0 issues
dart test -x live                   # 43/43 pass, no network needed
```

`stream_lifecycle_test.dart` covers the three required paths with an in-memory
fake process (no network, no subprocess): missing-binary launch failure →
error + close; unmapped non-zero exit → error + close; normal completion →
responses + summary + `PingSummary.errors`, plus close-exactly-once across all
terminal paths. A hung stream fails the test via a hard timeout.

Real-`ping` / network tests are tagged `@Tags(['live'])` (declared in
`dart_ping/dart_test.yaml`) and excluded from the deterministic gate; run them
on demand with `dart test -t live`.

## Note on review

An automated, multi-agent **code review was already completed in kandev** during
the Review step — see the planning task's plan artifact
("Code review — stream-lifecycle-robustness (#76)"). All findings (2 medium,
4 low, 2 info) were resolved and re-verified; the gate is green and
deterministic. Please do not re-trigger a separate review here.
