### PR TITLE
feat: NAT64 reachability for IPv4 literals on IPv6-only networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ iOS cannot use the same native subprocess approach as the other platforms, so th
 [dart_ping](dart_ping) is the main package which supports Windows, macOS, Linux, and Android natively without additional binaries.
 
 [dart_ping_ios](dart_ping_ios) is a Flutter plugin that adds iOS support through a native Swift ICMP engine distributed via Swift Package Manager (SPM). As of version 5.0.0 it ships no CocoaPods podspec and requires Flutter's SPM build mode; using it requires the Flutter SDK. CocoaPods-based projects that have not migrated to SPM should stay on the `4.x` line. See the [dart_ping_ios README](dart_ping_ios) for the SPM requirements and the 4.x → 5.x migration guide.
+
+### IPv6-only networks (NAT64)
+
+On an IPv6-only cellular network (NAT64/DNS64), an IPv4 literal such as `1.1.1.1` can be unreachable unless the platform synthesizes an IPv6 path to it. `Ping` exposes a `nat64Synthesis` option that is enabled by default, so an IPv4 literal keeps working on iOS without any code change. The active synthesis happens on iOS (via `dart_ping_ios`'s native engine); on the subprocess platforms (Windows, macOS, Linux, Android) the option is a no-op that leaves the ping command unchanged. Pass `nat64Synthesis: false` to opt out and restore raw pass-through.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,6 +1,6 @@
 # Requirements
 
-This document tracks six areas of work:
+This document tracks eight areas of work:
 
 1. **iOS SPM migration (#73)** — *shipped in `dart_ping_ios` 5.0.0.*
    Replace the `flutter_icmp_ping` dependency with a native Swift ICMP
@@ -43,6 +43,16 @@ This document tracks six areas of work:
    reusable round-trip-stats value object), folded into the
    already-unreleased breaking `dart_ping` 10.0.0 / `dart_ping_ios` 6.0.0
    majors. Captured in the `§req:stats-*` sections at the end.
+8. **NAT64 / IPv6-only IP-literal reachability (#52)** — on iOS over
+   cellular (mobile data), pinging a bare IPv4 literal fails outright,
+   while a hostname works and the same literal works over Wi-Fi, because
+   the carrier runs an IPv6-only (NAT64/DNS64) network that synthesizes a
+   routable address for hostnames but not for raw IP literals. Make the
+   literal ping actually succeed via the platform's NAT64 address
+   synthesis (as Apple's own guidance and third-party ping apps do),
+   behind an explicit option that is enabled by default — extending the
+   #69 scope boundary, which made the error honest but declined to make
+   the ping work. Captured in the `§req:nat64-*` sections at the end.
 
 ---
 
@@ -1159,3 +1169,224 @@ mechanism is decided:
 - **iOS surfacing mechanism** — how the native Swift engine exposes the
   per-probe data the stats are computed from, over the method channel, is
   a design task for `/plan`.
+
+---
+
+# NAT64 / IPv6-only IP-literal reachability (#52)
+
+A capability fix for `dart_ping_ios` (and, in principle, any platform
+that can synthesize): make pinging a bare IPv4 literal **succeed** on an
+IPv6-only cellular network, where today it fails outright. Driven by
+GitHub issue #52. This **extends the scope boundary of #69**
+(`§req:ipfamily-*`): #69 made the failure's *error* honest but
+deliberately declined to make the ping *work*, treating an IPv4 literal
+on an IPv6-only network as a legitimate no-route. #52 revisits that
+boundary — the evidence shows the ping can be made to succeed via the
+platform's NAT64 address synthesis, so the user-visible failure is
+avoidable, not inevitable.
+
+## NAT64 — problem statement §req:nat64-problem-statement
+
+The target users are Flutter/Dart developers using `dart_ping` /
+`dart_ping_ios` for ping diagnostics in apps that run on mobile devices —
+most acutely on iOS.
+
+The reported problem (#52): on iOS, on a **cellular / mobile-data**
+connection, pinging a **literal IPv4 address** (e.g. `13.35.27.1`) fails
+immediately with `unknownHost`, followed downstream by a timeout / "no
+stream event." The **same literal pings fine over Wi-Fi**, and pinging
+the target **by hostname succeeds even on the same cellular connection**.
+The failure reproduces on **physical hardware** (reported on iPhone 14
+Pro / Telstra 5G in Australia, and on 5G/LTE with US carriers) but **not
+on the iOS simulator**. Multiple developers report it.
+
+Underneath, modern carriers increasingly run **IPv6-only access networks
+with NAT64 + DNS64** (464XLAT). On such a network, a *hostname* is
+resolved by the system's DNS64, which hands back a **synthesized IPv6
+(NAT64) address** that routes to the IPv4 destination — so hostname pings
+work. A **bare IPv4 literal**, however, is handed straight to the network
+stack with no synthesis; there is no native IPv4 route, so the ping has
+nowhere to go and fails. Apple's own `SimplePing` sample (the lineage of
+the iOS engine) exhibits exactly this symptom unless it is made
+NAT64-aware.
+
+The tell that this is **fixable, not an immovable carrier wall**: on the
+*same phone and the same network*, **third-party "Ping" apps succeed**
+pinging the same IPv4 literal, and **Apple's updated `SimplePing`
+succeeds** once it synthesizes the NAT64 address. Apple documents the
+mechanism in *"Supporting IPv6 DNS64/NAT64 Networks"*: feed the IPv4
+literal through the system resolver (`getaddrinfo`), which on an
+IPv6-only network returns a **synthesized IPv6 address** that routes.
+Apps that do this reach the host; code that passes the raw IPv4 literal
+to the socket does not.
+
+This is where #52 diverges from #69. #69 closed the "hostname works, IP
+literal fails with *Unknown Host*" signature by making the **error
+honest** — an address-family / no-route failure is now reported as such,
+not as a phantom name-resolution failure — and its spec explicitly says
+the IPv4 literal "legitimately has no route" and that the work is
+"honesty, not new capability" (`§req:ipfamily-constraints`,
+`§spec:address-family-error-honesty`). #52's evidence contradicts the
+"legitimately has no route" premise: the route *can* be obtained via
+synthesis. The remaining gap, after #69, is that an affected user still
+**cannot ping an IP literal on mobile data at all** — they get an honest
+error instead of a misleading one, but the ping still does not work, when
+every other ping tool on the device makes it work.
+
+The problem is **growing** (carriers keep migrating to IPv6-only cores),
+**intermittent** (only on certain cellular networks), and **expensive to
+diagnose** — it cannot be reproduced on a developer's Wi-Fi or in the
+simulator, and it is easy to misattribute to the carrier. For affected
+users it is effectively a **total loss of IP-literal ping on mobile
+data**.
+
+## NAT64 — success criteria §req:nat64-success-criteria
+
+Observable, verifiable outcomes:
+
+- **The IPv4 literal pings successfully on an IPv6-only cellular
+  network.** On a network where the literal fails today, pinging it
+  produces the **same observable result as pinging it over Wi-Fi** —
+  responses with round-trip times and a normal summary — matching what
+  third-party ping apps achieve on the same device. *(must-have)*
+- **Controlled by an explicit option, enabled by default.** There is a
+  named, documented option that turns NAT64 / IPv6-only literal handling
+  on. With defaults, an affected user's existing call **starts working
+  with no code change**; a caller can **disable** the option to get the
+  prior raw pass-through behavior. Because not all platforms can
+  synthesize, the option's *effect* is platform-dependent (see
+  Constraints), but its presence and default are consistent. *(must-have)*
+- **When synthesis cannot help, the error stays honest.** On a
+  platform/network where the literal genuinely cannot be made reachable
+  (synthesis unsupported or unavailable, or a real no-route), the consumer
+  receives the honest typed error from #69 (no-route / address-family) —
+  **never a phantom `unknownHost`, never a silent hang/timeout**
+  (`§req:ipfamily-success-criteria` — "real failures surface
+  faithfully"). *(must-have)*
+- **The user-facing address family is unchanged by synthesis.** The
+  caller still selects IPv4 and pings an IPv4 literal; that the library
+  reaches it via a synthesized IPv6 / NAT64 address underneath is an
+  implementation detail and does not change the result shape or the
+  selected `IpVersion`. *(must-have)*
+- **Hostnames and Wi-Fi behavior are unchanged.** A hostname ping
+  (including a DNS64-synthesized one) and any ping that already works over
+  Wi-Fi or a dual-stack network behaves identically. *(regression guard)*
+- **No regression to #69 error honesty.** Turning the option off, or
+  hitting a genuinely unreachable target, reproduces #69's honest typed
+  errors exactly — including the literal-vs-family `ArgumentError`
+  (`§spec:address-family-mismatch-validation`). *(regression guard)*
+- **The behavior is covered by automated tests** that do not require a
+  live IPv6-only cellular network — the synthesis decision and the
+  option's on/off behavior are verifiable offline; the live end-to-end leg
+  is hand- / on-device-verified, as with #69. *(high)*
+
+## NAT64 — user stories §req:nat64-user-stories
+
+- As a developer whose users are on IPv6-only mobile data, I want pinging
+  an IPv4 literal to succeed the way it does over Wi-Fi — and the way
+  other ping apps do on the same phone — so my diagnostics don't silently
+  break on cellular.
+- As a developer, I want this handled **by default** so the fix reaches my
+  existing code with no change, but I want a documented switch to turn it
+  **off** if I need raw pass-through behavior.
+- As a developer on a network or platform where the literal truly cannot
+  be reached, I want the honest "no route for this family" error from #69
+  — not a phantom "unknown host" and not a five-second hang.
+- As a cross-platform developer, I want the same call to behave
+  consistently: where a platform can synthesize, the literal pings; where
+  it cannot, I get the same honest typed error everywhere, and the
+  difference is documented rather than surprising.
+- As an existing user who relies on current behavior, I want hostname
+  pings, Wi-Fi pings, and already-matching IP pings unchanged — and an
+  opt-out — so the only thing that changes is that a previously-failing
+  cellular IP-literal ping now works.
+
+## NAT64 — quality attributes §req:nat64-quality-attributes
+
+- **Reachability parity:** an IPv4 literal that other ping tools can reach
+  on a given phone and network should be reachable through `dart_ping`
+  too.
+- **Backward-compatible, default-on:** the option defaults to enabled so
+  affected users are fixed without code changes, while existing
+  well-behaved calls are unchanged and an opt-out restores prior behavior.
+- **Error honesty preserved:** synthesis is attempted first; a genuine
+  failure still surfaces the honest #69 typed error — never `unknownHost`,
+  never a hang (`§req:ipfamily-quality-attributes` — error honesty).
+- **Thinness / native fidelity:** the library leans on the **platform's
+  own** NAT64 synthesis (on iOS, the `getaddrinfo` path Apple documents),
+  not a hand-rolled DNS or NAT layer — it adds the synthesis hook the
+  platform expects and otherwise stays thin.
+- **Cross-platform consistency:** the same call yields the same Dart-side
+  outcome given the platform's capability; capability differences are
+  documented, not surprising.
+- **Testability:** the option and the synthesis decision are verifiable
+  without a live IPv6-only network; the live leg is on-device verified.
+
+## NAT64 — constraints §req:nat64-constraints
+
+- **Capability is platform-dependent and gated by an explicit option.**
+  Not every platform exposes NAT64 address synthesis, so the behavior is
+  controlled by an explicit option that **defaults to enabled** and is a
+  no-op where the platform cannot synthesize. **iOS is the reported and
+  primary target**; which other platforms participate is an open decision
+  for `/plan`.
+- **Stay thin — use the platform mechanism.** Prefer the platform's
+  documented synthesis path (on iOS, the `getaddrinfo` / NAT64 approach in
+  Apple's *"Supporting IPv6 DNS64/NAT64 Networks"*) over a custom
+  resolver. The library performs **no DNS of its own**.
+- **Do not regress #69.** The honest-error behavior and the exclusive
+  `IpVersion` selector from #69 remain. Synthesis sits **in front of**
+  them: it converts a previously-unreachable IPv4 literal into a reachable
+  one where possible, and otherwise yields the **same** honest typed
+  error. The literal-vs-family `ArgumentError` is unaffected.
+- **The user-facing family selection is unchanged.** Synthesis is an
+  under-the-hood route to the IPv4 target, not a switch of the caller's
+  selected address family.
+- **Not reproducible in CI.** Like #69, a live IPv6-only cellular network
+  is unavailable to hosted runners; **on-device verification** is required
+  for the end-to-end leg, while the option/decision logic is covered by
+  offline tests.
+- Traceable to issue #52; **extends / revises** the scope boundary of #69
+  (`§req:ipfamily-constraints` — "honesty, not new capability";
+  `§spec:address-family-error-honesty` — "scope boundary — honesty, not
+  new capability").
+
+## NAT64 — priorities §req:nat64-priorities
+
+- **Must-have:** IPv4-literal pings **succeed** on IPv6-only cellular
+  where the platform can synthesize, **on iOS at minimum**; behavior
+  controlled by an explicit, **default-enabled** option; the honest #69
+  error retained when synthesis cannot help; no regression to hostname or
+  Wi-Fi pings.
+- **High priority:** cross-platform consistency and clear documentation of
+  which platforms synthesize; offline automated tests for the option and
+  the synthesis decision.
+- **Nice-to-have:** extending synthesis beyond iOS where feasible;
+  documentation of NAT64 / DNS64 explaining why hostnames succeed where
+  bare IP literals historically failed.
+
+## NAT64 — open decisions §req:nat64-open-decisions
+
+Surfaced during discovery and deferred to `/symphonize:plan`, where
+mechanism is decided:
+
+- **Platform reach.** Which platforms beyond iOS actually gain synthesis
+  (Android's stack behavior on NAT64; whether desktop is in scope) is a
+  design task — the requirement is framed cross-platform but iOS is the
+  one confirmed target.
+- **Option shape, name, and default semantics.** The concrete name and
+  type of the explicit option, and exactly what "enabled by default"
+  means per platform (a no-op where unsupported vs. an error), are design
+  choices.
+- **iOS synthesis mechanism.** How the native Swift engine performs
+  synthesis (e.g. `getaddrinfo` on the literal with the appropriate flags,
+  and handling of the returned synthesized `sockaddr`) and where it sits
+  relative to the existing #69 resolve/send path.
+- **Fallback ordering.** Precisely when synthesis is attempted versus when
+  it yields to the honest #69 error (e.g. only when the selected family is
+  IPv4, the target is an IPv4 literal, and the network presents as
+  IPv6-only), and whether any of this is observable to the caller.
+- **Interaction with the `IpVersion` selector and #69 validation.**
+  Confirming that synthesis does not change the validated family or
+  disturb the literal-vs-family `ArgumentError`
+  (`§spec:address-family-mismatch-validation`).

--- a/SPEC.md
+++ b/SPEC.md
@@ -1850,7 +1850,21 @@ iOS is a nice-to-have deferred to those platforms' own evidence
 reach).
 
 ## NAT64 synthesis is an explicit, default-on option §spec:nat64-option
-*Status: not started*
+*Status: implemented (Batch #52-1) — the `Ping` factory accepts a named
+`bool nat64Synthesis` defaulting to enabled, threaded through `BasePing` (a
+stored field) and sent to the iOS bridge over the method channel in the `start`
+invocation alongside `ipVersion`. On the subprocess platforms (Linux/Android,
+macOS, Windows) it is a documented no-op: the field is carried but unread, so
+`params`/`command` stay byte-for-byte identical and the option never raises an
+error, keeping a cross-platform call identical. dartdoc on the factory
+parameter describes what it does, the default, which platform synthesizes (iOS)
+vs. treats it as a no-op, and that disabling restores raw pass-through;
+CHANGELOG (dart_ping 10.0.0 / dart_ping_ios 6.0.0) and the root README document
+it. Covered by network-free tests (`dart_ping/test/nat64_option_test.dart` —
+presence/default/threading plus the `params`/`command` no-op guard — and the
+`dart_ping_ios` bridge `start`-argument assertions). The native engine acting on
+the flag (actual NAT64 synthesis) lands in Batch #52-2,
+§spec:nat64-literal-synthesis / §spec:nat64-error-fallback.*
 
 NAT64 / IPv6-only literal handling is controlled by a single named option
 on the `Ping` factory that is **enabled by default**, so an affected user's
@@ -1955,7 +1969,16 @@ to alter the guard — confirming this is a design invariant, not a new code
 path (§req:nat64-open-decisions — interaction with #69 validation).
 
 ## NAT64 reachability tests §spec:nat64-tests
-*Status: not started*
+*Status: partially implemented (Batch #52-1) — the option-presence /
+default-enabled / threading bullet is covered offline:
+`dart_ping/test/nat64_option_test.dart` asserts the option defaults to enabled
+on every subprocess class, threads the supplied value, and is an inert no-op
+(`params`/`command` byte-for-byte unchanged), and
+`dart_ping_ios/test/dart_ping_ios_test.dart` asserts the bridge `start`
+arguments carry `nat64Synthesis` (true by default, false when disabled). The iOS
+resolve/send-seam + fallback-to-honest-error mapping bullet and the on-device
+live leg land in Batch #52-2 (§spec:nat64-literal-synthesis,
+§spec:nat64-error-fallback).*
 
 The option's on/off behavior and the synthesis-vs-honest-error decision are
 covered by automated tests that need no live IPv6-only cellular network; the

--- a/SPEC.md
+++ b/SPEC.md
@@ -1737,3 +1737,256 @@ discrimination out), so both are fully testable without a live network — the
 deterministic-seam principle the suite already follows (§spec:ci,
 §spec:coverage-expansion). Live ICMP round-trips remain the manual
 acceptance path; they are not where the statistics logic is verified.
+
+---
+
+# NAT64 / IPv6-only IP-literal reachability
+
+Solution-space design for issue #52 (`§req:nat64-*`): make pinging a bare
+IPv4 literal **succeed** on an IPv6-only cellular network, where it fails
+today, by reaching the target through the platform's own NAT64 address
+synthesis. The work is primarily in `dart_ping_ios` (the native Swift
+engine's resolve/send path) plus one new option on the shared `Ping`
+factory; it changes no result shape and no `IpVersion` semantics.
+
+The problem (from §req:nat64-problem-statement): on iOS over mobile data,
+pinging an IPv4 literal (e.g. `13.35.27.1`) fails outright, while the same
+literal works over Wi-Fi and a *hostname* works on the same cellular
+connection. The carrier runs an IPv6-only access network with NAT64/DNS64
+(464XLAT): a hostname is resolved by DNS64 to a synthesized IPv6 (NAT64)
+address that routes to the IPv4 host, but a raw IPv4 literal is handed to
+the stack with no synthesis and has no native IPv4 route. The tell that
+this is fixable, not a carrier wall: third-party ping apps and Apple's
+updated `SimplePing` reach the same literal on the same network once they
+feed it through the system resolver, which returns a synthesized address.
+
+This **revises the scope boundary of #69** (`§spec:address-family-error-honesty`,
+"scope boundary — honesty, not new capability"). #69 made the IPv4-literal
+failure's *error* honest (a typed `noRoute` instead of a phantom
+`unknownHost`) but treated the literal as having "legitimately no route."
+#52's evidence contradicts that premise — the route can be obtained via
+synthesis — so the deliverable here is the capability #69 declined to add:
+the ping actually works. Where synthesis cannot help, #69's honest typed
+error still stands; #52 sits **in front of** #69, not instead of it.
+
+**Why lean on the platform's synthesis rather than build our own:** the
+library does no DNS of its own (§req:nat64-constraints,
+§req:ipfamily-quality-attributes — thinness). The OS resolver already
+performs DNS64/NAT64 synthesis when not told to pin a family; Apple
+documents exactly this path in *"Supporting IPv6 DNS64/NAT64 Networks"*.
+The fix is therefore to stop suppressing synthesis on the literal path, not
+to add a NAT layer — keeping the engine thin and faithful to native
+behavior. A hand-rolled DNS64/NAT64 resolver was rejected: it would
+duplicate the platform stack, drift from carrier behavior, and violate the
+no-DNS constraint.
+
+## IPv4 literals reach IPv6-only networks via NAT64 synthesis §spec:nat64-literal-synthesis
+*Status: not started*
+
+On iOS, pinging an IPv4 literal on an IPv6-only (NAT64/DNS64) cellular
+network produces the **same observable result as pinging it over Wi-Fi** —
+replies with round-trip times and a normal summary — instead of failing
+outright. The library reaches the target through a platform-synthesized
+NAT64 address; the caller's selected family and the result shape are
+unchanged.
+
+- When NAT64 synthesis is enabled (§spec:nat64-option), the selected family
+  is `IpVersion.ipv4`, and the target is an **IPv4 literal**, the iOS engine
+  shall obtain the destination through the system resolver in a way that
+  lets the platform return a **synthesized NAT64 address** on an IPv6-only
+  network (and the plain IPv4 address on a dual-stack / Wi-Fi network), and
+  shall send ICMP/ICMPv6 echo probes to whichever address family the
+  resolver returns (§req:nat64-success-criteria — the literal pings
+  successfully; §req:nat64-problem-statement).
+- On a network where the IPv4 literal fails today, the consumer shall
+  receive responses, round-trip times, and a run summary equivalent to the
+  Wi-Fi result and to what third-party ping tools achieve on the same device
+  (§req:nat64-success-criteria — reachability parity;
+  §req:nat64-quality-attributes — reachability parity).
+- The caller's selected `IpVersion.ipv4` and the IPv4 literal it pinged
+  shall be unchanged by synthesis: that the host is reached via a synthesized
+  IPv6/NAT64 address underneath is an implementation detail and shall not
+  alter the result shape, the reported target, or the selected family
+  (§req:nat64-success-criteria — user-facing family unchanged;
+  §req:nat64-constraints — family selection unchanged).
+- A hostname ping (including a DNS64-synthesized one), a ping over Wi-Fi or
+  a dual-stack network, and an IPv4 literal that already routes shall behave
+  identically with synthesis enabled — synthesis changes only the
+  previously-unreachable IPv6-only-literal case
+  (§req:nat64-success-criteria — regression guard; §spec:ios-ping-behavior).
+
+**Why this scopes to an IPv4 literal under `IpVersion.ipv4`:** the reported
+failure is specific to a bare IPv4 literal — hostnames already get DNS64
+synthesis from the system resolver, an IPv6 literal needs none, and an
+`IpVersion.ipv6` selection is unaffected. Synthesis is therefore engaged
+only on the one path that is broken, leaving every working path untouched
+(§req:nat64-constraints — fallback ordering).
+
+**Why the engine sends to the resolver's returned family, relaxing #69's
+"never the other family" rule here:** #69 pins `ai_family` so a *hostname*
+never silently resolves to a family the caller did not select
+(§spec:address-family-error-honesty). For an IPv4 *literal* with synthesis
+enabled, reaching it via a synthesized IPv6/NAT64 address is not a silent
+family switch — it is NAT64 *transport* to the same IPv4 destination the
+caller named, and it is exactly what every other ping tool on the device
+does. The relaxation is deliberately narrow: IPv4 literal only, synthesis
+enabled only, and it changes the transport address, not the caller-selected
+`IpVersion`. Pinning the family on the literal path (the #69 behavior) is
+what suppresses synthesis and causes the failure; the opt-out
+(§spec:nat64-option) restores that pinned, raw-pass-through behavior for
+callers who want it. This narrow relaxation does not reopen #69's bug,
+whose signature was a *hostname* mislabeled and a routing failure reported
+as `unknownHost` — both still handled honestly here
+(§spec:nat64-error-fallback).
+
+**Why iOS is the primary (and only confirmed) target:** the failure is
+reported and reproducible on iOS over cellular, and Apple documents the
+synthesis path the engine owns. On the subprocess platforms the option is a
+documented no-op (§spec:nat64-option) — their native `ping` binaries do
+their own resolution, and Android's NAT64 handling (464XLAT/clatd) operates
+at the network layer below the binary. Extending active synthesis beyond
+iOS is a nice-to-have deferred to those platforms' own evidence
+(§req:nat64-priorities — nice-to-have; §req:nat64-open-decisions — platform
+reach).
+
+## NAT64 synthesis is an explicit, default-on option §spec:nat64-option
+*Status: not started*
+
+NAT64 / IPv6-only literal handling is controlled by a single named option
+on the `Ping` factory that is **enabled by default**, so an affected user's
+existing call starts working with no code change, and a caller can disable
+it to restore the prior raw-pass-through behavior.
+
+- The `Ping` factory shall accept a named, documented boolean option (e.g.
+  `nat64Synthesis`) that defaults to **enabled**, threaded to the iOS engine
+  the way `ipVersion` and `interface` already are
+  (§req:nat64-success-criteria — controlled by an explicit, default-on
+  option; §req:nat64-priorities — must-have).
+- With the option at its default, an affected caller's existing
+  IPv4-literal ping shall begin succeeding on an IPv6-only network with **no
+  source change**; with the option disabled, the engine shall use the prior
+  raw behavior (the family-pinned resolve of §spec:address-family-error-honesty,
+  no synthesis), reproducing the pre-#52 outcome
+  (§req:nat64-success-criteria — opt-out restores prior behavior;
+  §req:nat64-user-stories).
+- The option shall be present with the same name and default on every
+  platform; where a platform cannot synthesize, it shall be a documented
+  **no-op** rather than an error, so the cross-platform call stays identical
+  (§req:nat64-success-criteria — consistent presence and default;
+  §req:nat64-quality-attributes — cross-platform consistency;
+  §req:nat64-constraints — platform-dependent, gated by an explicit option).
+- The dartdoc shall describe what the option does, that it defaults to
+  enabled, which platforms actively synthesize (iOS) versus treat it as a
+  no-op, and that disabling it restores raw pass-through
+  (§req:nat64-priorities — high, documentation;
+  §req:nat64-quality-attributes — documented, not surprising).
+
+**Why default-on rather than opt-in:** the affected users cannot reproduce
+the failure on their own Wi-Fi or in the simulator, and the fix should reach
+their existing code without their having to discover and set a flag
+(§req:nat64-problem-statement — expensive to diagnose;
+§req:nat64-priorities — must-have). The behavior also matches user
+expectation — every other ping tool on the device already reaches the
+literal — so "works by default" is the least surprising default. The opt-out
+exists for callers who deliberately want raw pass-through (e.g. to observe
+the un-synthesized failure), preserving backward compatibility as a choice
+rather than the default (§req:nat64-quality-attributes — backward-compatible,
+default-on).
+
+**Why one boolean rather than a richer policy object:** the only decision a
+caller makes is "let the platform synthesize, or pass the literal raw," a
+binary choice; the per-platform capability difference is fixed by the
+platform, not configured. A boolean keeps the surface minimal and the
+default obvious (§req:nat64-constraints — option shape). A multi-valued
+"NAT64 mode" was rejected for the same reason `IpVersion` rejected an
+"auto/dual-stack" value (§spec:ipv6-address-family-selector): named modes
+imply behaviors the library does not offer.
+
+## Synthesis precedes the honest #69 error, and yields to it §spec:nat64-error-fallback
+*Status: not started*
+
+Synthesis is attempted first; when it cannot produce a routable address —
+synthesis unsupported, no synthesized address available, or a genuine
+no-route — the consumer receives #69's honest typed error, never a phantom
+`unknownHost` and never a silent hang. #69's error honesty and its
+literal-vs-family `ArgumentError` are preserved exactly.
+
+- When the option is enabled but the platform returns no synthesized or
+  otherwise routable address for the IPv4 literal, the engine shall surface
+  the honest typed error from #69 — `ErrorType.noRoute` for an
+  address-family / no-route condition, `unknownHost` only for a genuine
+  name-resolution failure — and shall **never** report a phantom
+  `unknownHost` for a routing failure nor hang/time out silently
+  (§req:nat64-success-criteria — error stays honest when synthesis cannot
+  help; §spec:address-family-error-honesty).
+- When the option is disabled, or the target is genuinely unreachable, the
+  engine shall reproduce #69's honest typed errors exactly, including the
+  reserved meaning of `unknownHost` (§req:nat64-success-criteria — no
+  regression to #69 error honesty; §spec:address-family-error-honesty).
+- Synthesis shall not disturb the synchronous literal-vs-family
+  `ArgumentError`: an `IpVersion.ipv4` selection with an IPv4 literal matches
+  and is never rejected (synthesis operates within this matched case), and a
+  mismatched literal (e.g. `IpVersion.ipv4` with an IPv6 literal) still
+  throws before any stream starts, unchanged by this option
+  (§req:nat64-constraints — do not regress #69;
+  §spec:address-family-mismatch-validation).
+- The user-facing `IpVersion` selection shall be unchanged by the fallback
+  path as well: whether synthesis succeeds or yields to the honest error, the
+  caller's selected family is the one validated and reported
+  (§req:nat64-constraints — family selection unchanged;
+  §req:nat64-open-decisions — interaction with the `IpVersion` selector).
+
+**Why synthesis-first, honest-error-second:** the requirement is to make the
+ping *work* where it can while keeping the *error honest* where it cannot
+(§req:nat64-success-criteria). Attempting synthesis first converts the
+previously-unreachable literal into a reachable one on a NAT64 network;
+falling back to #69's typed error on genuine failure means the consumer
+never loses the diagnostic honesty #69 established. The two are complementary
+layers, not alternatives — #52 adds capability in front of #69's honesty
+without removing it (§spec:address-family-error-honesty — scope boundary,
+now revised).
+
+**Why the `ArgumentError` is untouched:** that guard fires only on a
+literal whose family *contradicts* the selection
+(§spec:address-family-mismatch-validation); #52's case is a *matching*
+IPv4-literal-under-`IpVersion.ipv4`, which the guard lets through. Synthesis
+therefore operates entirely inside the already-valid case and has no reason
+to alter the guard — confirming this is a design invariant, not a new code
+path (§req:nat64-open-decisions — interaction with #69 validation).
+
+## NAT64 reachability tests §spec:nat64-tests
+*Status: not started*
+
+The option's on/off behavior and the synthesis-vs-honest-error decision are
+covered by automated tests that need no live IPv6-only cellular network; the
+live end-to-end leg is hand- / on-device-verified, as with #69.
+
+- The option's presence, default-enabled value, and threading to the engine
+  shall be covered by network-free tests over pure input (the constructed
+  `Ping` / bridge arguments), including that the default is enabled and that
+  disabling it selects the raw path
+  (§req:nat64-success-criteria — automated tests offline;
+  §req:nat64-priorities — high; §spec:nat64-option).
+- The synthesis decision and the fallback-to-honest-error mapping shall be
+  covered at the iOS resolve/send seam: with synthesis on, an IPv4 literal
+  drives the un-pinned resolve path; with it off, the family-pinned path;
+  and a resolver outcome that yields no routable address maps to the honest
+  `noRoute` / `unknownHost` error rather than a phantom or a hang — all
+  without a live process (§req:nat64-success-criteria — synthesis decision
+  and on/off verifiable offline; §spec:nat64-literal-synthesis,
+  §spec:nat64-error-fallback).
+- The live leg — an IPv4 literal actually pinging through on an IPv6-only
+  cellular network — shall be an on-device acceptance step, not a CI gate
+  (§req:nat64-success-criteria — live leg on-device-verified;
+  §req:nat64-constraints — not reproducible in CI).
+
+**Why offline seams plus an on-device leg:** a live IPv6-only cellular
+network is unavailable to hosted runners and not reproducible in the
+simulator (§req:nat64-constraints — not reproducible in CI), exactly the
+constraint #69 faced (§spec:address-family-error-tests). The testable
+surface is the pure logic — option default and threading (input in →
+arguments out) and the resolve-path / error-mapping decision (selection +
+resolver outcome in → synthesized-send or typed-error out) — while the
+end-to-end reachability is verified by hand on an affected device, mirroring
+the suite's established deterministic-seam principle (§spec:ci,
+§spec:ios-tests).

--- a/SPEC.md
+++ b/SPEC.md
@@ -1789,12 +1789,18 @@ calls `getaddrinfo` with `AF_UNSPEC` and no `AI_NUMERICHOST` (gated by the pure
 return a synthesized NAT64 address on an IPv6-only network (and the plain IPv4
 address on Wi-Fi / dual-stack); it then sends ICMP/ICMPv6 to whichever TRANSPORT
 family the resolver returns while the caller-selected `IpVersion` is unchanged.
+When the resolver returns BOTH a synthesized IPv6 address and the original IPv4
+literal, the engine PREFERS the IPv6 (NAT64) address rather than committing to
+whichever entry `getaddrinfo` sorted first — the bare IPv4 literal has no route
+on an IPv6-only network, so first-entry selection could silently defeat the fix;
+this routable-family choice lives in the pure `PingEngine.synthesizedTransport(hasIPv4:hasIPv6:)`.
 Every other path keeps #69's byte-for-byte family-pinned resolve. The synthesis
-decision is offline-covered by the network-free `shouldSynthesize` /
-`isIPv4Literal` XCTest cases in the example's `RunnerTests` (iOS + macOS targets);
-the Swift change is not compilable on the Linux CI host (hand-verified; macOS CI
-`xcodebuild test` compiles/runs it). The live IPv6-only-cellular reachability leg
-is an on-device acceptance step (§spec:nat64-tests).*
+decision and the address-selection policy are offline-covered by the network-free
+`shouldSynthesize` / `isIPv4Literal` / `synthesizedTransport` XCTest cases in the
+example's `RunnerTests` (iOS + macOS targets); the Swift change is not compilable
+on the Linux CI host (hand-verified; macOS CI `xcodebuild test` compiles/runs it).
+The live IPv6-only-cellular reachability leg is an on-device acceptance step
+(§spec:nat64-tests).*
 
 On iOS, pinging an IPv4 literal on an IPv6-only (NAT64/DNS64) cellular
 network produces the **same observable result as pinging it over Wi-Fi** —
@@ -2004,13 +2010,18 @@ the option-presence / default-enabled / threading bullet is covered offline
 defaults to enabled on every subprocess class, threads the supplied value, and is
 an inert no-op (`params`/`command` byte-for-byte unchanged), and
 `dart_ping_ios/test/dart_ping_ios_test.dart` asserts the bridge `start` arguments
-carry `nat64Synthesis` (true by default, false when disabled, and pinned on the
-IPv4-literal + `IpVersion.ipv4` path the engine synthesizes for). The synthesis
-decision and the fallback-to-honest-error mapping land in Batch #52-2: the
-network-free `shouldSynthesize` / `isIPv4Literal` and the
-`errorKind(forGetaddrinfoStatus:)` / `errorKind(forSendErrno:)` XCTest cases in
-the example's `RunnerTests` (iOS + macOS targets) pin the un-pinned-vs-pinned
-resolve decision and the honest `.noRoute` / `.unknownHost` classification, and
+carry `nat64Synthesis` (true by default, false when disabled, and forwarded
+verbatim for the IPv4-literal + `IpVersion.ipv4` argument shape). That Dart test
+covers only the bridge's verbatim threading — the synthesis DECISION itself is a
+native concern and is covered by `RunnerTests` below, not by the bridge test. The
+synthesis decision, the routable-address selection, and the fallback-to-honest-
+error mapping land in Batch #52-2: the network-free `shouldSynthesize` /
+`isIPv4Literal` / `synthesizedTransport` (the prefer-IPv6-over-a-co-listed-IPv4-
+literal selection policy) and the `errorKind(forGetaddrinfoStatus:)` /
+`errorKind(forSendErrno:)` XCTest cases in the example's `RunnerTests` (iOS +
+macOS targets) pin the un-pinned-vs-pinned resolve decision, the
+synthesized-family choice, and the honest `.noRoute` / `.unknownHost`
+classification, and
 `dart_ping_ios/test/ping_event_mapper_test.dart` pins the Dart mapping seam
 (native `No Route` / `Unknown Host` -> the honest typed `PingError`, never a
 phantom or null) plus the synthesis-on regression guards (a normal reply still

--- a/SPEC.md
+++ b/SPEC.md
@@ -1781,7 +1781,20 @@ duplicate the platform stack, drift from carrier behavior, and violate the
 no-DNS constraint.
 
 ## IPv4 literals reach IPv6-only networks via NAT64 synthesis §spec:nat64-literal-synthesis
-*Status: not started*
+*Status: implemented (Batch #52-2) — the iOS Swift engine un-pins the resolve for
+the narrow IPv4-literal + synthesis-enabled + `IpVersion.ipv4` case only: it
+calls `getaddrinfo` with `AF_UNSPEC` and no `AI_NUMERICHOST` (gated by the pure
+`PingEngine.shouldSynthesize(family:nat64Synthesis:host:)`, which is true iff
+`nat64Synthesis && family == .v4 && isIPv4Literal(host)`), so the platform may
+return a synthesized NAT64 address on an IPv6-only network (and the plain IPv4
+address on Wi-Fi / dual-stack); it then sends ICMP/ICMPv6 to whichever TRANSPORT
+family the resolver returns while the caller-selected `IpVersion` is unchanged.
+Every other path keeps #69's byte-for-byte family-pinned resolve. The synthesis
+decision is offline-covered by the network-free `shouldSynthesize` /
+`isIPv4Literal` XCTest cases in the example's `RunnerTests` (iOS + macOS targets);
+the Swift change is not compilable on the Linux CI host (hand-verified; macOS CI
+`xcodebuild test` compiles/runs it). The live IPv6-only-cellular reachability leg
+is an on-device acceptance step (§spec:nat64-tests).*
 
 On iOS, pinging an IPv4 literal on an IPv6-only (NAT64/DNS64) cellular
 network produces the **same observable result as pinging it over Wi-Fi** —
@@ -1917,7 +1930,23 @@ default obvious (§req:nat64-constraints — option shape). A multi-valued
 imply behaviors the library does not offer.
 
 ## Synthesis precedes the honest #69 error, and yields to it §spec:nat64-error-fallback
-*Status: not started*
+*Status: implemented (Batch #52-2) — when synthesis cannot produce a routable
+address for the IPv4 literal, the engine surfaces #69's honest typed error:
+an address-family / no-route condition becomes `ErrorType.noRoute`, never a
+phantom `unknownHost` and never a silent hang, and `unknownHost` stays reserved
+for a genuine name miss. With synthesis disabled, or for a genuinely-unreachable
+target, the engine reproduces #69 exactly (the family-pinned resolve), and the
+synchronous literal-vs-family `ArgumentError` is untouched (it fires only on a
+contradicting literal, never on the matching IPv4-literal-under-`IpVersion.ipv4`
+case synthesis operates within). The honest classification is covered by the
+network-free `errorKind(forGetaddrinfoStatus:)` / `errorKind(forSendErrno:)`
+XCTest cases in `RunnerTests` (`EAI_NODATA`/`EAI_ADDRFAMILY`/`EAI_FAMILY` ->
+`.noRoute`, `EAI_NONAME` -> `.unknownHost`;
+`ENETUNREACH`/`EHOSTUNREACH`/`EAFNOSUPPORT`/`EADDRNOTAVAIL` -> `.noRoute`), and
+the Dart mapping seam by `dart_ping_ios/test/ping_event_mapper_test.dart`
+(native `No Route` -> `ErrorType.noRoute`, `Unknown Host` -> `ErrorType.unknownHost`,
+both honest typed errors, never a phantom or null). The Swift classification is
+not compilable on the Linux CI host (hand-verified; macOS CI runs it).*
 
 Synthesis is attempted first; when it cannot produce a routable address —
 synthesis unsupported, no synthesized address available, or a genuine
@@ -1969,16 +1998,28 @@ to alter the guard — confirming this is a design invariant, not a new code
 path (§req:nat64-open-decisions — interaction with #69 validation).
 
 ## NAT64 reachability tests §spec:nat64-tests
-*Status: partially implemented (Batch #52-1) — the option-presence /
-default-enabled / threading bullet is covered offline:
-`dart_ping/test/nat64_option_test.dart` asserts the option defaults to enabled
-on every subprocess class, threads the supplied value, and is an inert no-op
-(`params`/`command` byte-for-byte unchanged), and
-`dart_ping_ios/test/dart_ping_ios_test.dart` asserts the bridge `start`
-arguments carry `nat64Synthesis` (true by default, false when disabled). The iOS
-resolve/send-seam + fallback-to-honest-error mapping bullet and the on-device
-live leg land in Batch #52-2 (§spec:nat64-literal-synthesis,
-§spec:nat64-error-fallback).*
+*Status: implemented offline (Batches #52-1, #52-2); live leg on-device only —
+the option-presence / default-enabled / threading bullet is covered offline
+(Batch #52-1): `dart_ping/test/nat64_option_test.dart` asserts the option
+defaults to enabled on every subprocess class, threads the supplied value, and is
+an inert no-op (`params`/`command` byte-for-byte unchanged), and
+`dart_ping_ios/test/dart_ping_ios_test.dart` asserts the bridge `start` arguments
+carry `nat64Synthesis` (true by default, false when disabled, and pinned on the
+IPv4-literal + `IpVersion.ipv4` path the engine synthesizes for). The synthesis
+decision and the fallback-to-honest-error mapping land in Batch #52-2: the
+network-free `shouldSynthesize` / `isIPv4Literal` and the
+`errorKind(forGetaddrinfoStatus:)` / `errorKind(forSendErrno:)` XCTest cases in
+the example's `RunnerTests` (iOS + macOS targets) pin the un-pinned-vs-pinned
+resolve decision and the honest `.noRoute` / `.unknownHost` classification, and
+`dart_ping_ios/test/ping_event_mapper_test.dart` pins the Dart mapping seam
+(native `No Route` / `Unknown Host` -> the honest typed `PingError`, never a
+phantom or null) plus the synthesis-on regression guards (a normal reply still
+maps to an intact `PingResponse` with its stats snapshot). The Dart seams run
+green under `flutter test` on the Linux CI host; the Swift seams are hand-verified
+(not compilable on Linux; macOS CI `xcodebuild test` compiles/runs them). The
+remaining manual step is the live leg — an IPv4 literal actually pinging through
+on an IPv6-only cellular network — an on-device acceptance step, not a CI gate
+(§spec:nat64-literal-synthesis, §spec:nat64-error-fallback).*
 
 The option's on/off behavior and the synthesis-vs-honest-error decision are
 covered by automated tests that need no live IPv6-only cellular network; the

--- a/dart_ping/CHANGELOG.md
+++ b/dart_ping/CHANGELOG.md
@@ -61,6 +61,18 @@ Sub-millisecond precision / serialization (#63, §spec:stats-precision):
   too small under 10.0.0 (a millisecond magnitude read as microseconds), so do
   not mix serialized round-trip values across the major boundary.
 
+NAT64/IPv6-only reachability (#52, §spec:nat64-option):
+
+- New default-on `nat64Synthesis` boolean on the `Ping` factory. On an
+  IPv6-only (NAT64/DNS64) network an IPv4 literal is otherwise unreachable;
+  enabling synthesis lets the platform reach it. The active behavior is
+  delivered on iOS by `dart_ping_ios` (its native engine synthesizes the
+  IPv6 path); on the subprocess platforms (Linux/Android, macOS, Windows) the
+  option is an inert no-op carried purely for cross-platform parity — it
+  leaves the spawned command and its parameters byte-for-byte unchanged and
+  never raises an error. Passing `nat64Synthesis: false` restores raw
+  pass-through (the family-pinned resolve, no synthesis).
+
 ## 9.2.0
 
 - Add an optional `interface` selection to the `Ping` factory and the platform constructors (#72). Pass either a network interface name (e.g. `eth0`) or a local source IP address (e.g. `192.168.1.5`) to bind the ping to a specific interface or source address.

--- a/dart_ping/lib/src/ping/base_ping.dart
+++ b/dart_ping/lib/src/ping/base_ping.dart
@@ -21,6 +21,7 @@ abstract class BasePing {
     this.encoding,
     this.forceCodepage,
     this.interface,
+    this.nat64Synthesis,
   ) {
     // Enforce the literal/family guard on EVERY construction path, not only the
     // `Ping(...)` factory — direct construction of a platform class must fail
@@ -90,6 +91,18 @@ abstract class BasePing {
   bool get interfaceIsAddress =>
       hasInterface &&
       InternetAddress.tryParse(interface!.split('%').first) != null;
+
+  /// Whether the platform may reach an IPv4 literal on an IPv6-only
+  /// (NAT64/DNS64) network via the platform's own address synthesis
+  /// (§spec:nat64-option).
+  ///
+  /// Defaults to enabled. It is actively honored ONLY on iOS, where the native
+  /// engine can synthesize an IPv6 path to an IPv4 literal. On the subprocess
+  /// platforms (Linux/Android, macOS, Windows) it is carried purely for
+  /// cross-platform option parity and is an inert NO-OP: it does NOT alter
+  /// [params] or [command]. Disabling it restores raw pass-through (the
+  /// family-pinned resolve, no synthesis).
+  bool nat64Synthesis;
 
   // Concurrent-isolation invariant (#70): every field below is instance-local
   // mutable state. Each `Ping`/`BasePing` owns its own OS [_process] (and thus

--- a/dart_ping/lib/src/ping/linux_ping.dart
+++ b/dart_ping/lib/src/ping/linux_ping.dart
@@ -14,6 +14,7 @@ class PingLinux extends BasePing implements Ping {
     PingParser? parser,
     Encoding encoding = const Utf8Codec(),
     String? interface,
+    bool nat64Synthesis = true,
   }) : super(
           host,
           count,
@@ -25,6 +26,7 @@ class PingLinux extends BasePing implements Ping {
           encoding,
           false,
           interface,
+          nat64Synthesis,
         );
 
   static PingParser get defaultParser => PingParser(

--- a/dart_ping/lib/src/ping/mac_ping.dart
+++ b/dart_ping/lib/src/ping/mac_ping.dart
@@ -14,6 +14,7 @@ class PingMac extends BasePing implements Ping {
     PingParser? parser,
     Encoding encoding = const Utf8Codec(),
     String? interface,
+    bool nat64Synthesis = true,
   }) : super(
           host,
           count,
@@ -25,6 +26,7 @@ class PingMac extends BasePing implements Ping {
           encoding,
           false,
           interface,
+          nat64Synthesis,
         );
 
   static PingParser get defaultParser => PingParser(

--- a/dart_ping/lib/src/ping/windows_ping.dart
+++ b/dart_ping/lib/src/ping/windows_ping.dart
@@ -15,6 +15,7 @@ class PingWindows extends BasePing implements Ping {
     Encoding encoding = const Utf8Codec(allowMalformed: true),
     bool forceCodepage = false,
     String? interface,
+    bool nat64Synthesis = true,
   }) : super(
           host,
           count,
@@ -26,6 +27,7 @@ class PingWindows extends BasePing implements Ping {
           encoding,
           forceCodepage,
           interface,
+          nat64Synthesis,
         ) {
     // Windows `ping` binds ONLY by source address, never by interface name.
     // Reject a bare name once, up front at construction (consistent with the

--- a/dart_ping/lib/src/ping_interface.dart
+++ b/dart_ping/lib/src/ping_interface.dart
@@ -71,6 +71,18 @@ abstract class Ping {
     /// flag(s) its `ping` supports (Linux/Android: both; macOS: both; Windows:
     /// address only). Omitting it leaves the produced command unchanged.
     String? interface,
+
+    /// Whether the platform may reach an IPv4 literal on an IPv6-only
+    /// (NAT64/DNS64) network via the platform's own address synthesis
+    /// (§spec:nat64-option).
+    ///
+    /// Defaults to enabled. It is actively honored ONLY on iOS, where the
+    /// native engine synthesizes an IPv6 path to an IPv4 literal. On the
+    /// subprocess platforms (Linux/Android, macOS, Windows) it is a documented
+    /// NO-OP carried purely for cross-platform option parity — it never alters
+    /// the produced command and never raises an error. Disabling it restores
+    /// raw pass-through: the family-pinned resolve with no synthesis.
+    bool nat64Synthesis = true,
   }) {
     // Synchronous address-family guard: if [host] is a literal IP address, its
     // family MUST match the selected [ipVersion]. This runs before any platform
@@ -95,6 +107,7 @@ abstract class Ping {
           parser: parser,
           encoding: encoding,
           interface: interface,
+          nat64Synthesis: nat64Synthesis,
         );
       case 'macos':
         return PingMac(
@@ -107,6 +120,7 @@ abstract class Ping {
           parser: parser,
           encoding: encoding,
           interface: interface,
+          nat64Synthesis: nat64Synthesis,
         );
       case 'windows':
         return PingWindows(
@@ -120,6 +134,7 @@ abstract class Ping {
           encoding: encoding,
           forceCodepage: forceCodepage,
           interface: interface,
+          nat64Synthesis: nat64Synthesis,
         );
       case 'ios':
         throwIfInterfaceUnsupportedOnIos(interface);
@@ -134,6 +149,7 @@ abstract class Ping {
             ipVersion,
             parser,
             encoding,
+            nat64Synthesis,
           );
         }
         throw UnimplementedError(
@@ -153,6 +169,7 @@ abstract class Ping {
     IpVersion ipVersion,
     PingParser? parser,
     Encoding encoding,
+    bool nat64Synthesis,
   )? iosFactory;
 
   /// Parser used to interpret ping process output

--- a/dart_ping/test/nat64_option_test.dart
+++ b/dart_ping/test/nat64_option_test.dart
@@ -1,0 +1,108 @@
+import 'package:dart_ping/dart_ping.dart';
+import 'package:dart_ping/src/ping/linux_ping.dart';
+import 'package:dart_ping/src/ping/mac_ping.dart';
+import 'package:dart_ping/src/ping/windows_ping.dart';
+import 'package:test/test.dart';
+
+/// Coverage for the cross-platform `nat64Synthesis` option surface on the
+/// subprocess platform classes (§spec:nat64-tests).
+///
+/// The option is default-on and threaded onto `BasePing.nat64Synthesis`, but on
+/// the subprocess platforms (Linux/Android, macOS, Windows) it is an inert
+/// NO-OP: it carries the option for cross-platform parity yet must NOT alter
+/// `params` or `command`. These tests construct each platform class directly —
+/// the same style as `platform_test.dart` — so they exercise every platform on
+/// any host without spawning a process.
+void main() {
+  group('PingLinux', () {
+    test('nat64Synthesis defaults to enabled when the option is omitted', () {
+      final ping = PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4);
+      expect(ping.nat64Synthesis, isTrue);
+    });
+
+    test('nat64Synthesis threads the supplied value (true / false)', () {
+      final enabled =
+          PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4, nat64Synthesis: true);
+      final disabled =
+          PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4, nat64Synthesis: false);
+      expect(enabled.nat64Synthesis, isTrue);
+      expect(disabled.nat64Synthesis, isFalse);
+    });
+
+    test('the option is an inert NO-OP: params/command are byte-for-byte equal',
+        () {
+      // Backward-compat guard: whether the option is omitted (default),
+      // explicitly true, or explicitly false, the spawned command must be
+      // identical — proving the subprocess option never touches the raw path.
+      final baseline = PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4);
+      final enabled =
+          PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4, nat64Synthesis: true);
+      final disabled =
+          PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4, nat64Synthesis: false);
+      expect(enabled.params, baseline.params);
+      expect(enabled.command, baseline.command);
+      expect(disabled.params, baseline.params);
+      expect(disabled.command, baseline.command);
+    });
+  });
+
+  group('PingMac', () {
+    test('nat64Synthesis defaults to enabled when the option is omitted', () {
+      final ping = PingMac('host', 3, 1, 2, 64, IpVersion.ipv4);
+      expect(ping.nat64Synthesis, isTrue);
+    });
+
+    test('nat64Synthesis threads the supplied value (true / false)', () {
+      final enabled =
+          PingMac('host', 3, 1, 2, 64, IpVersion.ipv4, nat64Synthesis: true);
+      final disabled =
+          PingMac('host', 3, 1, 2, 64, IpVersion.ipv4, nat64Synthesis: false);
+      expect(enabled.nat64Synthesis, isTrue);
+      expect(disabled.nat64Synthesis, isFalse);
+    });
+
+    test('the option is an inert NO-OP: params/command are byte-for-byte equal',
+        () {
+      final baseline = PingMac('host', 3, 1, 2, 64, IpVersion.ipv4);
+      final enabled =
+          PingMac('host', 3, 1, 2, 64, IpVersion.ipv4, nat64Synthesis: true);
+      final disabled =
+          PingMac('host', 3, 1, 2, 64, IpVersion.ipv4, nat64Synthesis: false);
+      expect(enabled.params, baseline.params);
+      expect(enabled.command, baseline.command);
+      expect(disabled.params, baseline.params);
+      expect(disabled.command, baseline.command);
+    });
+  });
+
+  group('PingWindows', () {
+    // Windows rejects IPv6 and bare interface names, so these cases stay on
+    // IpVersion.ipv4 with no interface to construct cleanly.
+    test('nat64Synthesis defaults to enabled when the option is omitted', () {
+      final ping = PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4);
+      expect(ping.nat64Synthesis, isTrue);
+    });
+
+    test('nat64Synthesis threads the supplied value (true / false)', () {
+      final enabled = PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4,
+          nat64Synthesis: true);
+      final disabled = PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4,
+          nat64Synthesis: false);
+      expect(enabled.nat64Synthesis, isTrue);
+      expect(disabled.nat64Synthesis, isFalse);
+    });
+
+    test('the option is an inert NO-OP: params/command are byte-for-byte equal',
+        () {
+      final baseline = PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4);
+      final enabled = PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4,
+          nat64Synthesis: true);
+      final disabled = PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4,
+          nat64Synthesis: false);
+      expect(enabled.params, baseline.params);
+      expect(enabled.command, baseline.command);
+      expect(disabled.params, baseline.params);
+      expect(disabled.command, baseline.command);
+    });
+  });
+}

--- a/dart_ping_ios/CHANGELOG.md
+++ b/dart_ping_ios/CHANGELOG.md
@@ -33,6 +33,12 @@
   distinguish it from a true name miss).
 - An IPv6 reply whose hop limit cannot be recovered (no `IPV6_HOPLIMIT`
   control message) now reports a null `ttl` instead of a misleading `0`.
+- **NAT64/IPv6-only reachability (#52):** the iOS bridge now forwards the
+  default-on `nat64Synthesis` option to the native engine over the method
+  channel, so an IPv4 literal can be made to reach an IPv6-only/NAT64 network.
+  This batch wires the option through at the bridge level; the live native
+  synthesis (the engine acting on the flag) is completed in the follow-on
+  batch. Requires `dart_ping` ^10.0.0.
 
 ## 5.1.0
 

--- a/dart_ping_ios/README.md
+++ b/dart_ping_ios/README.md
@@ -67,6 +67,24 @@ Note that local-network ping does **not** trigger iOS's Local Network privacy
 prompt. That prompt applies to LAN-discovery APIs, not to ICMP echo sent to a
 routable host, so its absence here is expected and not a defect.
 
+### NAT64 IPv4-literal reachability: on-device acceptance step
+
+NAT64 IPv4-literal synthesis (the default-on `nat64Synthesis` option) has a
+**manual on-device acceptance step** that is **not a CI gate** — a live
+IPv6-only cellular network cannot be reproduced on hosted runners or the iOS
+simulator, so this mirrors #69's deterministic-seam principle (the offline
+decision/error seams are covered by network-free `RunnerTests` and Dart tests;
+only the live reachability leg is hand-verified).
+
+On an affected device joined to an **IPv6-only cellular network**:
+
+1. Ping an IPv4 literal (e.g. `13.35.27.1`) under `IpVersion.ipv4` with the
+   default `nat64Synthesis: true`. Expected: replies with round-trip times and a
+   normal run summary — **the same observable result as over Wi-Fi**.
+2. Re-run the same ping with `nat64Synthesis: false`. Expected: the prior honest
+   `noRoute` error (the un-synthesized failure), never a phantom `unknownHost`
+   and never a silent hang.
+
 ## Usage
 
 The key to using this package is to import it and call this method before you use dart_ping:

--- a/dart_ping_ios/example/ios/RunnerTests/RunnerTests.swift
+++ b/dart_ping_ios/example/ios/RunnerTests/RunnerTests.swift
@@ -498,4 +498,94 @@ class RunnerTests: XCTestCase {
     XCTAssertNil(ICMPPacket.parseTimeExceededOriginalSequenceV6(truncated))
   }
 
+  // MARK: - §spec:nat64-tests — NAT64 synthesis decision + honest-error fallback
+  //
+  // The NAT64 reachability fix (#52) un-pins the resolve for the ONE narrow case
+  // of an IPv4 literal under IpVersion.ipv4 with synthesis enabled. The decision
+  // itself (`shouldSynthesize`/`isIPv4Literal`) and the honest error
+  // classification on the synthesis-failure path are pure/static, so they are
+  // pinned here WITHOUT a live process — a real IPv6-only NAT64 cellular network
+  // is not reproducible on a hosted runner or the simulator, so the end-to-end
+  // reachability leg is an on-device acceptance step (§spec:nat64-literal-synthesis,
+  // §spec:nat64-error-fallback). These offline seams are the testable surface.
+
+  // MARK: shouldSynthesize(family:nat64Synthesis:host:) — the SOLE relaxation gate
+
+  /// The relaxation engages ONLY for an IPv4 literal, IpVersion.ipv4, synthesis
+  /// enabled — the single previously-broken path. Offline: this is the pure
+  /// decision the engine consults before un-pinning the resolve; no socket needed.
+  func testShouldSynthesizeTrueForIPv4LiteralWithSynthesisEnabled() {
+    XCTAssertTrue(PingEngine.shouldSynthesize(family: .v4, nat64Synthesis: true, host: "13.35.27.1"))
+    // A second IPv4 literal: still engaged.
+    XCTAssertTrue(PingEngine.shouldSynthesize(family: .v4, nat64Synthesis: true, host: "1.1.1.1"))
+  }
+
+  /// Every other combination keeps #69's pinned, raw resolve. Offline rationale:
+  /// the gate is the whole behavioral boundary, so each disqualifying input is
+  /// pinned here rather than discovered on an (unavailable) live NAT64 network.
+  func testShouldSynthesizeFalseForEveryNonEngagedCase() {
+    // Synthesis disabled (opt-out) -> raw, family-pinned path even for a literal.
+    XCTAssertFalse(PingEngine.shouldSynthesize(family: .v4, nat64Synthesis: false, host: "13.35.27.1"))
+    // IpVersion.ipv6 selection is unaffected by the IPv4-literal relaxation.
+    XCTAssertFalse(PingEngine.shouldSynthesize(family: .v6, nat64Synthesis: true, host: "13.35.27.1"))
+    // A hostname already gets DNS64 from the system resolver; not this gate.
+    XCTAssertFalse(PingEngine.shouldSynthesize(family: .v4, nat64Synthesis: true, host: "example.com"))
+    // An IPv6 literal is not an IPv4 literal; no synthesis.
+    XCTAssertFalse(PingEngine.shouldSynthesize(family: .v4, nat64Synthesis: true, host: "2001:4860:4860::8888"))
+  }
+
+  // MARK: isIPv4Literal(_:)
+
+  /// Dotted-quads are IPv4 literals (inet_pton(AF_INET) accepts them). Offline:
+  /// purely numeric classification, no DNS, no socket (§spec:nat64-tests).
+  func testIsIPv4LiteralTrueForDottedQuads() {
+    XCTAssertTrue(PingEngine.isIPv4Literal("13.35.27.1"))
+    XCTAssertTrue(PingEngine.isIPv4Literal("0.0.0.0"))
+    XCTAssertTrue(PingEngine.isIPv4Literal("255.255.255.255"))
+  }
+
+  /// Hostnames, IPv6 literals, the empty string, and a malformed quad (an octet
+  /// > 255) are NOT IPv4 literals, so they never trip the synthesis gate. Offline:
+  /// inet_pton rejects each form deterministically with no network.
+  func testIsIPv4LiteralFalseForNonLiterals() {
+    XCTAssertFalse(PingEngine.isIPv4Literal("example.com"))
+    XCTAssertFalse(PingEngine.isIPv4Literal("2001:4860:4860::8888"))
+    XCTAssertFalse(PingEngine.isIPv4Literal(""))
+    XCTAssertFalse(PingEngine.isIPv4Literal("999.1.1.1")) // 999 > 255: malformed
+  }
+
+  // MARK: honest error classification on the synthesis-failure path
+  // (§spec:nat64-error-fallback)
+  //
+  // When synthesis cannot produce a routable address, the engine must fall back
+  // to #69's honest typed error: an address-family / route failure becomes
+  // .noRoute, and .unknownHost is reserved for a GENUINE name miss — never a
+  // phantom unknownHost for a routing failure, never a silent hang. These reuse
+  // the EXISTING #69 helpers (`errorKind(forGetaddrinfoStatus:)` /
+  // `errorKind(forSendErrno:)`); this test documents that those same classifications
+  // hold on the NAT64 synthesis fallback path. Offline: a pure status/errno ->
+  // PingErrorKind mapping, asserted without a live NAT64 network.
+
+  /// getaddrinfo statuses reachable when the un-pinned (AF_UNSPEC) synthesis
+  /// resolve yields no usable/family-appropriate record map to .noRoute, while a
+  /// genuine name miss stays .unknownHost — the honesty boundary #52 must keep.
+  func testSynthesisFallbackGetaddrinfoStatusesClassifyHonestly() {
+    // No record of a usable family for the resolved literal -> route/family fail.
+    XCTAssertEqual(PingEngine.errorKind(forGetaddrinfoStatus: EAI_NODATA), .noRoute)
+    XCTAssertEqual(PingEngine.errorKind(forGetaddrinfoStatus: EAI_ADDRFAMILY), .noRoute)
+    XCTAssertEqual(PingEngine.errorKind(forGetaddrinfoStatus: EAI_FAMILY), .noRoute)
+    // A genuine name miss is the ONLY thing that stays unknownHost (never phantom).
+    XCTAssertEqual(PingEngine.errorKind(forGetaddrinfoStatus: EAI_NONAME), .unknownHost)
+  }
+
+  /// send(2) errnos for the synthesized/route-failed destination all classify as
+  /// .noRoute — the honest "this family can't be reached here" signal #52 falls
+  /// back to when synthesis does not yield a routable path.
+  func testSynthesisFallbackSendErrnosClassifyAsNoRoute() {
+    XCTAssertEqual(PingEngine.errorKind(forSendErrno: ENETUNREACH), .noRoute)
+    XCTAssertEqual(PingEngine.errorKind(forSendErrno: EHOSTUNREACH), .noRoute)
+    XCTAssertEqual(PingEngine.errorKind(forSendErrno: EAFNOSUPPORT), .noRoute)
+    XCTAssertEqual(PingEngine.errorKind(forSendErrno: EADDRNOTAVAIL), .noRoute)
+  }
+
 }

--- a/dart_ping_ios/example/ios/RunnerTests/RunnerTests.swift
+++ b/dart_ping_ios/example/ios/RunnerTests/RunnerTests.swift
@@ -588,4 +588,36 @@ class RunnerTests: XCTestCase {
     XCTAssertEqual(PingEngine.errorKind(forSendErrno: EADDRNOTAVAIL), .noRoute)
   }
 
+  // MARK: synthesizedTransport(hasIPv4:hasIPv6:) — the address-selection policy
+  // (§spec:nat64-literal-synthesis / §spec:nat64-tests)
+  //
+  // The un-pinned (AF_UNSPEC) resolve may return BOTH the synthesized IPv6
+  // (NAT64) address and the original IPv4 literal. The engine must NOT commit to
+  // whichever entry getaddrinfo sorted first — on an IPv6-only network the IPv4
+  // literal is unroutable, and picking it would silently defeat #52. This pure
+  // policy encodes the routable-family preference; it is the offline seam over
+  // the synthesis address selection (a live IPv6-only NAT64 network is not
+  // reproducible on a hosted runner / the simulator).
+
+  /// Both families synthesized -> prefer IPv6 (the routable NAT64 address). This
+  /// is the exact #52 case: a bare IPv4 literal on an IPv6-only network where the
+  /// resolver returns the synthesized v6 alongside the original (unroutable) v4.
+  func testSynthesizedTransportPrefersIPv6WhenBothPresent() {
+    XCTAssertEqual(PingEngine.synthesizedTransport(hasIPv4: true, hasIPv6: true), .v6)
+    // IPv6 alone (pure synthesis) is also v6.
+    XCTAssertEqual(PingEngine.synthesizedTransport(hasIPv4: false, hasIPv6: true), .v6)
+  }
+
+  /// No IPv6 synthesized (dual-stack / Wi-Fi, where the literal already routes)
+  /// -> send over IPv4, unchanged from the pre-#52 behavior.
+  func testSynthesizedTransportUsesIPv4WhenNoIPv6() {
+    XCTAssertEqual(PingEngine.synthesizedTransport(hasIPv4: true, hasIPv6: false), .v4)
+  }
+
+  /// Resolver returned no usable address -> nil, which the resolve path maps to
+  /// the honest `.noRoute` (never a phantom unknownHost, never a hang).
+  func testSynthesizedTransportNilWhenNeitherPresent() {
+    XCTAssertNil(PingEngine.synthesizedTransport(hasIPv4: false, hasIPv6: false))
+  }
+
 }

--- a/dart_ping_ios/example/macos/RunnerTests/RunnerTests.swift
+++ b/dart_ping_ios/example/macos/RunnerTests/RunnerTests.swift
@@ -498,4 +498,94 @@ class RunnerTests: XCTestCase {
     XCTAssertNil(ICMPPacket.parseTimeExceededOriginalSequenceV6(truncated))
   }
 
+  // MARK: - §spec:nat64-tests — NAT64 synthesis decision + honest-error fallback
+  //
+  // The NAT64 reachability fix (#52) un-pins the resolve for the ONE narrow case
+  // of an IPv4 literal under IpVersion.ipv4 with synthesis enabled. The decision
+  // itself (`shouldSynthesize`/`isIPv4Literal`) and the honest error
+  // classification on the synthesis-failure path are pure/static, so they are
+  // pinned here WITHOUT a live process — a real IPv6-only NAT64 cellular network
+  // is not reproducible on a hosted runner or the simulator, so the end-to-end
+  // reachability leg is an on-device acceptance step (§spec:nat64-literal-synthesis,
+  // §spec:nat64-error-fallback). These offline seams are the testable surface.
+
+  // MARK: shouldSynthesize(family:nat64Synthesis:host:) — the SOLE relaxation gate
+
+  /// The relaxation engages ONLY for an IPv4 literal, IpVersion.ipv4, synthesis
+  /// enabled — the single previously-broken path. Offline: this is the pure
+  /// decision the engine consults before un-pinning the resolve; no socket needed.
+  func testShouldSynthesizeTrueForIPv4LiteralWithSynthesisEnabled() {
+    XCTAssertTrue(PingEngine.shouldSynthesize(family: .v4, nat64Synthesis: true, host: "13.35.27.1"))
+    // A second IPv4 literal: still engaged.
+    XCTAssertTrue(PingEngine.shouldSynthesize(family: .v4, nat64Synthesis: true, host: "1.1.1.1"))
+  }
+
+  /// Every other combination keeps #69's pinned, raw resolve. Offline rationale:
+  /// the gate is the whole behavioral boundary, so each disqualifying input is
+  /// pinned here rather than discovered on an (unavailable) live NAT64 network.
+  func testShouldSynthesizeFalseForEveryNonEngagedCase() {
+    // Synthesis disabled (opt-out) -> raw, family-pinned path even for a literal.
+    XCTAssertFalse(PingEngine.shouldSynthesize(family: .v4, nat64Synthesis: false, host: "13.35.27.1"))
+    // IpVersion.ipv6 selection is unaffected by the IPv4-literal relaxation.
+    XCTAssertFalse(PingEngine.shouldSynthesize(family: .v6, nat64Synthesis: true, host: "13.35.27.1"))
+    // A hostname already gets DNS64 from the system resolver; not this gate.
+    XCTAssertFalse(PingEngine.shouldSynthesize(family: .v4, nat64Synthesis: true, host: "example.com"))
+    // An IPv6 literal is not an IPv4 literal; no synthesis.
+    XCTAssertFalse(PingEngine.shouldSynthesize(family: .v4, nat64Synthesis: true, host: "2001:4860:4860::8888"))
+  }
+
+  // MARK: isIPv4Literal(_:)
+
+  /// Dotted-quads are IPv4 literals (inet_pton(AF_INET) accepts them). Offline:
+  /// purely numeric classification, no DNS, no socket (§spec:nat64-tests).
+  func testIsIPv4LiteralTrueForDottedQuads() {
+    XCTAssertTrue(PingEngine.isIPv4Literal("13.35.27.1"))
+    XCTAssertTrue(PingEngine.isIPv4Literal("0.0.0.0"))
+    XCTAssertTrue(PingEngine.isIPv4Literal("255.255.255.255"))
+  }
+
+  /// Hostnames, IPv6 literals, the empty string, and a malformed quad (an octet
+  /// > 255) are NOT IPv4 literals, so they never trip the synthesis gate. Offline:
+  /// inet_pton rejects each form deterministically with no network.
+  func testIsIPv4LiteralFalseForNonLiterals() {
+    XCTAssertFalse(PingEngine.isIPv4Literal("example.com"))
+    XCTAssertFalse(PingEngine.isIPv4Literal("2001:4860:4860::8888"))
+    XCTAssertFalse(PingEngine.isIPv4Literal(""))
+    XCTAssertFalse(PingEngine.isIPv4Literal("999.1.1.1")) // 999 > 255: malformed
+  }
+
+  // MARK: honest error classification on the synthesis-failure path
+  // (§spec:nat64-error-fallback)
+  //
+  // When synthesis cannot produce a routable address, the engine must fall back
+  // to #69's honest typed error: an address-family / route failure becomes
+  // .noRoute, and .unknownHost is reserved for a GENUINE name miss — never a
+  // phantom unknownHost for a routing failure, never a silent hang. These reuse
+  // the EXISTING #69 helpers (`errorKind(forGetaddrinfoStatus:)` /
+  // `errorKind(forSendErrno:)`); this test documents that those same classifications
+  // hold on the NAT64 synthesis fallback path. Offline: a pure status/errno ->
+  // PingErrorKind mapping, asserted without a live NAT64 network.
+
+  /// getaddrinfo statuses reachable when the un-pinned (AF_UNSPEC) synthesis
+  /// resolve yields no usable/family-appropriate record map to .noRoute, while a
+  /// genuine name miss stays .unknownHost — the honesty boundary #52 must keep.
+  func testSynthesisFallbackGetaddrinfoStatusesClassifyHonestly() {
+    // No record of a usable family for the resolved literal -> route/family fail.
+    XCTAssertEqual(PingEngine.errorKind(forGetaddrinfoStatus: EAI_NODATA), .noRoute)
+    XCTAssertEqual(PingEngine.errorKind(forGetaddrinfoStatus: EAI_ADDRFAMILY), .noRoute)
+    XCTAssertEqual(PingEngine.errorKind(forGetaddrinfoStatus: EAI_FAMILY), .noRoute)
+    // A genuine name miss is the ONLY thing that stays unknownHost (never phantom).
+    XCTAssertEqual(PingEngine.errorKind(forGetaddrinfoStatus: EAI_NONAME), .unknownHost)
+  }
+
+  /// send(2) errnos for the synthesized/route-failed destination all classify as
+  /// .noRoute — the honest "this family can't be reached here" signal #52 falls
+  /// back to when synthesis does not yield a routable path.
+  func testSynthesisFallbackSendErrnosClassifyAsNoRoute() {
+    XCTAssertEqual(PingEngine.errorKind(forSendErrno: ENETUNREACH), .noRoute)
+    XCTAssertEqual(PingEngine.errorKind(forSendErrno: EHOSTUNREACH), .noRoute)
+    XCTAssertEqual(PingEngine.errorKind(forSendErrno: EAFNOSUPPORT), .noRoute)
+    XCTAssertEqual(PingEngine.errorKind(forSendErrno: EADDRNOTAVAIL), .noRoute)
+  }
+
 }

--- a/dart_ping_ios/example/macos/RunnerTests/RunnerTests.swift
+++ b/dart_ping_ios/example/macos/RunnerTests/RunnerTests.swift
@@ -588,4 +588,36 @@ class RunnerTests: XCTestCase {
     XCTAssertEqual(PingEngine.errorKind(forSendErrno: EADDRNOTAVAIL), .noRoute)
   }
 
+  // MARK: synthesizedTransport(hasIPv4:hasIPv6:) — the address-selection policy
+  // (§spec:nat64-literal-synthesis / §spec:nat64-tests)
+  //
+  // The un-pinned (AF_UNSPEC) resolve may return BOTH the synthesized IPv6
+  // (NAT64) address and the original IPv4 literal. The engine must NOT commit to
+  // whichever entry getaddrinfo sorted first — on an IPv6-only network the IPv4
+  // literal is unroutable, and picking it would silently defeat #52. This pure
+  // policy encodes the routable-family preference; it is the offline seam over
+  // the synthesis address selection (a live IPv6-only NAT64 network is not
+  // reproducible on a hosted runner / the simulator).
+
+  /// Both families synthesized -> prefer IPv6 (the routable NAT64 address). This
+  /// is the exact #52 case: a bare IPv4 literal on an IPv6-only network where the
+  /// resolver returns the synthesized v6 alongside the original (unroutable) v4.
+  func testSynthesizedTransportPrefersIPv6WhenBothPresent() {
+    XCTAssertEqual(PingEngine.synthesizedTransport(hasIPv4: true, hasIPv6: true), .v6)
+    // IPv6 alone (pure synthesis) is also v6.
+    XCTAssertEqual(PingEngine.synthesizedTransport(hasIPv4: false, hasIPv6: true), .v6)
+  }
+
+  /// No IPv6 synthesized (dual-stack / Wi-Fi, where the literal already routes)
+  /// -> send over IPv4, unchanged from the pre-#52 behavior.
+  func testSynthesizedTransportUsesIPv4WhenNoIPv6() {
+    XCTAssertEqual(PingEngine.synthesizedTransport(hasIPv4: true, hasIPv6: false), .v4)
+  }
+
+  /// Resolver returned no usable address -> nil, which the resolve path maps to
+  /// the honest `.noRoute` (never a phantom unknownHost, never a hang).
+  func testSynthesizedTransportNilWhenNeitherPresent() {
+    XCTAssertNil(PingEngine.synthesizedTransport(hasIPv4: false, hasIPv6: false))
+  }
+
 }

--- a/dart_ping_ios/ios/dart_ping_ios/Sources/dart_ping_ios/DartPingIosPlugin.swift
+++ b/dart_ping_ios/ios/dart_ping_ios/Sources/dart_ping_ios/DartPingIosPlugin.swift
@@ -26,6 +26,11 @@
 //      ipVersion: a string, the selected address family — "ipv4" or "ipv6"
 //                 (the `IpVersion` enum name). Anything other than "ipv6" maps
 //                 to IPv4. The engine resolves AND sends for this family only.
+//      nat64Synthesis: a bool, default true, gating the NAT64 relaxation. When
+//                 true and the selected family is "ipv4" and the host is an IPv4
+//                 literal, the engine lets the platform synthesize a NAT64
+//                 address so the literal reaches an IPv6-only network; otherwise
+//                 it keeps the family-pinned resolve (§spec:nat64-literal-synthesis).
 //
 //  Threading: `FlutterEventSink` must be invoked on the platform/main thread,
 //  but `PingEngine` delivers events on a background queue, so every sink call
@@ -135,6 +140,9 @@ public class DartPingIosPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
         // ("ipv4" / "ipv6"); default to IPv4 for any absent/unexpected value.
         let ipVersion = (args["ipVersion"] as? String) ?? "ipv4"
         let family: IPFamily = (ipVersion == "ipv6") ? .v6 : .v4
+        // Default-on to match the option's default (§spec:nat64-option); the Dart
+        // bridge always sends it, but absence/unexpected falls back to enabled.
+        let nat64Synthesis = (args["nat64Synthesis"] as? Bool) ?? true
 
         let config = PingEngine.Config(
             host: host,
@@ -142,7 +150,8 @@ public class DartPingIosPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
             interval: interval,
             timeout: timeout,
             ttl: ttl,
-            family: family
+            family: family,
+            nat64Synthesis: nat64Synthesis
         )
 
         let engine = PingEngine(config: config) { [weak self] event in

--- a/dart_ping_ios/ios/dart_ping_ios/Sources/dart_ping_ios/PingEngine.swift
+++ b/dart_ping_ios/ios/dart_ping_ios/Sources/dart_ping_ios/PingEngine.swift
@@ -339,10 +339,78 @@ public final class PingEngine {
     /// Pure/static so the decision is testable without the network. This is the
     /// SOLE gate that relaxes #69's pinned resolve; everything else keeps the
     /// byte-for-byte family-pinned behavior (§spec:nat64-literal-synthesis).
+    ///
+    /// The IPv4-literal classification is recomputed natively here even though the
+    /// Dart layer already parses the host and enforces the literal/family guard
+    /// before the run reaches the channel. That is DELIBERATE defense-in-depth: the
+    /// engine consumes method-channel arguments from outside its own trust
+    /// boundary and must not assume the caller validated them, so it independently
+    /// decides whether to un-pin rather than trusting a flag it was handed.
     public static func shouldSynthesize(family: IPFamily,
                                         nat64Synthesis: Bool,
                                         host: String) -> Bool {
         return nat64Synthesis && family == .v4 && isIPv4Literal(host)
+    }
+
+    /// Choose the transport family for the un-pinned NAT64 synthesis resolve from
+    /// the families the resolver actually returned. Prefers IPv6 — the synthesized
+    /// NAT64 address, which is the routable one on an IPv6-only network — over a
+    /// co-listed IPv4 literal that has NO route there (sending to it would fail
+    /// `ENETUNREACH` or time out). Falls back to IPv4 when no IPv6 address was
+    /// synthesized (dual-stack / Wi-Fi). Returns nil when neither family is
+    /// present, which the caller maps to the honest `.noRoute`.
+    ///
+    /// This is the fix for relying on `getaddrinfo` result ORDER: rather than
+    /// committing to whichever entry happened to sort first (which could be the
+    /// unroutable IPv4 literal, silently defeating NAT64 on the exact network #52
+    /// targets), the routable family is chosen explicitly. Pure/static so
+    /// RunnerTests can pin the preference WITHOUT a live resolver — the offline
+    /// seam over the synthesis address-selection policy (§spec:nat64-tests).
+    public static func synthesizedTransport(hasIPv4: Bool, hasIPv6: Bool) -> IPFamily? {
+        if hasIPv6 { return .v6 }
+        if hasIPv4 { return .v4 }
+        return nil
+    }
+
+    /// Run `getaddrinfo(host)` with the given `aiFamily` hint (AF_INET / AF_INET6
+    /// for the pinned path, AF_UNSPEC for synthesis) and a SOCK_DGRAM socktype,
+    /// then hand the result list to `select`, which returns the chosen
+    /// destination (already copied into a `sockaddr_storage`) plus its transport
+    /// family, or nil when the list holds no usable address.
+    ///
+    /// This centralizes the getaddrinfo LIFECYCLE — the status guard and the
+    /// leak-safe `freeaddrinfo` on every exit — so the pinned (#69) and
+    /// synthesized (#52) paths share ONE copy of that reasoning instead of two
+    /// that can drift. On a getaddrinfo failure the status is classified by
+    /// `failureKind` (so each path keeps its own honesty rule); a resolved-but-
+    /// empty selection is a route problem for the host, hence `.noRoute`.
+    private static func resolved(
+        host: String,
+        aiFamily: Int32,
+        failureKind: (Int32) -> PingErrorKind,
+        select: (UnsafeMutablePointer<addrinfo>) -> (sockaddr_storage, socklen_t, IPFamily)?
+    ) -> Resolution {
+        var hints = addrinfo()
+        hints.ai_family = aiFamily
+        hints.ai_socktype = SOCK_DGRAM
+        // NB: do NOT constrain ai_protocol to IPPROTO_ICMP(V6) here. getaddrinfo
+        // validates the socktype/protocol pair and rejects SOCK_DGRAM+ICMP with
+        // EAI_BADHINTS, which would make every host resolve as a failure. The
+        // protocol only matters for the socket() call, not for name resolution.
+        // AI_NUMERICHOST is also left unset so the AF_UNSPEC path can synthesize.
+
+        var result: UnsafeMutablePointer<addrinfo>?
+        let status = getaddrinfo(host, nil, &hints, &result)
+        guard status == 0, let first = result else {
+            if result != nil { freeaddrinfo(result) }
+            return .failure(failureKind(status))
+        }
+        defer { freeaddrinfo(first) }
+
+        guard let (addr, addrLen, transport) = select(first) else {
+            return .failure(.noRoute)
+        }
+        return .success(addr, addrLen, transport)
     }
 
     /// Resolve `host` to a destination plus the TRANSPORT family to send for.
@@ -360,40 +428,27 @@ public final class PingEngine {
             return resolveSynthesized(host: host)
         }
 
-        var hints = addrinfo()
-        hints.ai_family = (family == .v4) ? AF_INET : AF_INET6  // pinned; never the other family
-        hints.ai_socktype = SOCK_DGRAM
-        // NB: do NOT constrain ai_protocol to IPPROTO_ICMP(V6) here. getaddrinfo
-        // validates the socktype/protocol pair and rejects SOCK_DGRAM+ICMP with
-        // EAI_BADHINTS, which would make every host resolve as a failure. The
-        // protocol only matters for the socket() call, not for name resolution.
-
-        var result: UnsafeMutablePointer<addrinfo>?
-        let status = getaddrinfo(host, nil, &hints, &result)
-        guard status == 0, let first = result else {
-            if result != nil { freeaddrinfo(result) }
-            return .failure(Self.errorKind(forGetaddrinfoStatus: status))
-        }
-        defer { freeaddrinfo(first) }
-
-        // Walk the list for the first entry matching the requested family and
-        // copy its sockaddr into a sockaddr_storage with the right socklen.
+        // Pinned to the selected family. The first entry of that family wins; the
+        // transport family equals the requested family (no synthesis).
         let wantFamily: Int32 = (family == .v4) ? AF_INET : AF_INET6
-        var node: UnsafeMutablePointer<addrinfo>? = first
-        while let current = node {
-            if current.pointee.ai_family == wantFamily,
-               let sa = current.pointee.ai_addr {
-                // Pinned path: transport family == the requested family.
-                let (out, wantLen) = Self.copyDestination(from: sa,
-                                                          addrLen: current.pointee.ai_addrlen,
-                                                          transport: family)
-                return .success(out, wantLen, family)
+        return Self.resolved(host: host,
+                             aiFamily: wantFamily,
+                             failureKind: { Self.errorKind(forGetaddrinfoStatus: $0) }) { first in
+            var node: UnsafeMutablePointer<addrinfo>? = first
+            while let current = node {
+                if current.pointee.ai_family == wantFamily,
+                   let sa = current.pointee.ai_addr {
+                    let (out, wantLen) = Self.copyDestination(from: sa,
+                                                              addrLen: current.pointee.ai_addrlen,
+                                                              transport: family)
+                    return (out, wantLen, family)
+                }
+                node = current.pointee.ai_next
             }
-            node = current.pointee.ai_next
+            // Resolved but no address of the selected family: a route problem,
+            // not a name miss (mapped to .noRoute by `resolved`).
+            return nil
         }
-        // getaddrinfo succeeded but returned no address of the selected family:
-        // there is no route for this family, not a name miss.
-        return .failure(.noRoute)
     }
 
     /// Resolve an IPv4 literal WITHOUT pinning the address family, so the system
@@ -404,44 +459,57 @@ public final class PingEngine {
     /// `AI_NUMERICHOST`: that flag would short-circuit the resolver and suppress
     /// synthesis, which is exactly the pinned behavior this path relaxes.
     ///
-    /// We take the FIRST result whose family is AF_INET or AF_INET6 and return it
-    /// as the transport family (`.v6` for AF_INET6, else `.v4`).
+    /// We PREFER the synthesized IPv6 (NAT64) address over a co-listed IPv4
+    /// literal (see `synthesizedTransport(hasIPv4:hasIPv6:)`) rather than taking
+    /// whichever entry sorted first, so the engine never silently commits to the
+    /// unroutable IPv4 literal on the very IPv6-only network this fix targets.
     ///
     /// Honest classification (§spec:nat64-error-fallback): an IPv4 literal that
     /// yields no routable address is a ROUTE problem, so ANY failure here
     /// (non-zero status OR no usable address) maps to `.noRoute`, NEVER
     /// `.unknownHost` — it is a literal, never a name miss.
     private func resolveSynthesized(host: String) -> Resolution {
-        var hints = addrinfo()
-        hints.ai_family = AF_UNSPEC          // let the resolver synthesize / choose
-        hints.ai_socktype = SOCK_DGRAM
-        // NB: do NOT set AI_NUMERICHOST — see the doc comment above.
-
-        var result: UnsafeMutablePointer<addrinfo>?
-        let status = getaddrinfo(host, nil, &hints, &result)
-        guard status == 0, let first = result else {
-            if result != nil { freeaddrinfo(result) }
-            return .failure(.noRoute)
-        }
-        defer { freeaddrinfo(first) }
-
-        // Walk the list for the first AF_INET / AF_INET6 entry and copy its
-        // sockaddr into a sockaddr_storage via the shared copyDestination helper.
-        var node: UnsafeMutablePointer<addrinfo>? = first
-        while let current = node {
-            let fam = current.pointee.ai_family
-            if (fam == AF_INET || fam == AF_INET6), let sa = current.pointee.ai_addr {
-                let transport: IPFamily = (fam == AF_INET6) ? .v6 : .v4
-                let (out, wantLen) = Self.copyDestination(from: sa,
-                                                          addrLen: current.pointee.ai_addrlen,
-                                                          transport: transport)
-                return .success(out, wantLen, transport)
+        // AF_UNSPEC: let the resolver synthesize / choose. ANY failure is a route
+        // problem for a literal (never a name miss), so failureKind is always
+        // .noRoute and the empty-selection case also maps to .noRoute.
+        return Self.resolved(host: host,
+                             aiFamily: AF_UNSPEC,
+                             failureKind: { _ in .noRoute }) { first in
+            // The resolver may return BOTH the synthesized IPv6 (NAT64) address
+            // and the original IPv4 literal. Capture the first entry of each
+            // family, then let the pure `synthesizedTransport` policy pick the
+            // routable one (IPv6 when synthesized) — not whichever sorted first.
+            var v4: (UnsafeMutablePointer<sockaddr>, socklen_t)?
+            var v6: (UnsafeMutablePointer<sockaddr>, socklen_t)?
+            var node: UnsafeMutablePointer<addrinfo>? = first
+            while let current = node {
+                if let sa = current.pointee.ai_addr {
+                    let len = current.pointee.ai_addrlen
+                    switch current.pointee.ai_family {
+                    case AF_INET6 where v6 == nil: v6 = (sa, len)
+                    case AF_INET where v4 == nil: v4 = (sa, len)
+                    default: break
+                    }
+                }
+                node = current.pointee.ai_next
             }
-            node = current.pointee.ai_next
+            // Resolved but no usable IPv4/IPv6 address -> nil -> .noRoute via `resolved`.
+            guard let transport = Self.synthesizedTransport(hasIPv4: v4 != nil,
+                                                            hasIPv6: v6 != nil) else {
+                return nil
+            }
+            // The chosen family is guaranteed present by the policy above, so the
+            // force-unwrap is total: .v6 only when v6 != nil, .v4 only when v4 != nil.
+            let entry: (UnsafeMutablePointer<sockaddr>, socklen_t)
+            switch transport {
+            case .v6: entry = v6!
+            case .v4: entry = v4!
+            }
+            let (out, wantLen) = Self.copyDestination(from: entry.0,
+                                                      addrLen: entry.1,
+                                                      transport: transport)
+            return (out, wantLen, transport)
         }
-        // Resolved but no usable IPv4/IPv6 address: a route problem for this
-        // literal, not a name miss.
-        return .failure(.noRoute)
     }
 
     /// Copy a resolved entry's `sockaddr` (`ai_addr`/`ai_addrlen`) into a

--- a/dart_ping_ios/ios/dart_ping_ios/Sources/dart_ping_ios/PingEngine.swift
+++ b/dart_ping_ios/ios/dart_ping_ios/Sources/dart_ping_ios/PingEngine.swift
@@ -379,20 +379,14 @@ public final class PingEngine {
         // Walk the list for the first entry matching the requested family and
         // copy its sockaddr into a sockaddr_storage with the right socklen.
         let wantFamily: Int32 = (family == .v4) ? AF_INET : AF_INET6
-        let wantLen = socklen_t((family == .v4) ? MemoryLayout<sockaddr_in>.size
-                                                : MemoryLayout<sockaddr_in6>.size)
         var node: UnsafeMutablePointer<addrinfo>? = first
         while let current = node {
             if current.pointee.ai_family == wantFamily,
                let sa = current.pointee.ai_addr {
-                var out = sockaddr_storage()
-                let copyLen = min(Int(wantLen), Int(current.pointee.ai_addrlen))
-                withUnsafeMutablePointer(to: &out) { dst in
-                    dst.withMemoryRebound(to: UInt8.self, capacity: copyLen) { dstBytes in
-                        memcpy(dstBytes, sa, copyLen)
-                    }
-                }
                 // Pinned path: transport family == the requested family.
+                let (out, wantLen) = Self.copyDestination(from: sa,
+                                                          addrLen: current.pointee.ai_addrlen,
+                                                          transport: family)
                 return .success(out, wantLen, family)
             }
             node = current.pointee.ai_next
@@ -432,22 +426,15 @@ public final class PingEngine {
         defer { freeaddrinfo(first) }
 
         // Walk the list for the first AF_INET / AF_INET6 entry and copy its
-        // sockaddr into a sockaddr_storage with the matching socklen (same
-        // memcpy-with-min-length pattern the pinned resolve uses).
+        // sockaddr into a sockaddr_storage via the shared copyDestination helper.
         var node: UnsafeMutablePointer<addrinfo>? = first
         while let current = node {
             let fam = current.pointee.ai_family
             if (fam == AF_INET || fam == AF_INET6), let sa = current.pointee.ai_addr {
                 let transport: IPFamily = (fam == AF_INET6) ? .v6 : .v4
-                let wantLen = socklen_t((transport == .v4) ? MemoryLayout<sockaddr_in>.size
-                                                           : MemoryLayout<sockaddr_in6>.size)
-                var out = sockaddr_storage()
-                let copyLen = min(Int(wantLen), Int(current.pointee.ai_addrlen))
-                withUnsafeMutablePointer(to: &out) { dst in
-                    dst.withMemoryRebound(to: UInt8.self, capacity: copyLen) { dstBytes in
-                        memcpy(dstBytes, sa, copyLen)
-                    }
-                }
+                let (out, wantLen) = Self.copyDestination(from: sa,
+                                                          addrLen: current.pointee.ai_addrlen,
+                                                          transport: transport)
                 return .success(out, wantLen, transport)
             }
             node = current.pointee.ai_next
@@ -455,6 +442,27 @@ public final class PingEngine {
         // Resolved but no usable IPv4/IPv6 address: a route problem for this
         // literal, not a name miss.
         return .failure(.noRoute)
+    }
+
+    /// Copy a resolved entry's `sockaddr` (`ai_addr`/`ai_addrlen`) into a
+    /// `sockaddr_storage` sized for `transport`, returning it with the matching
+    /// socklen for `sendto`. The copy is bounded to `min(wantLen, addrLen)` so a
+    /// short `ai_addr` can never read past the source. This is the load-bearing
+    /// manual pointer copy shared by BOTH resolve paths (pinned and synthesized)
+    /// — kept in one place so the bounds reasoning lives once.
+    private static func copyDestination(from sa: UnsafePointer<sockaddr>,
+                                        addrLen: socklen_t,
+                                        transport: IPFamily) -> (sockaddr_storage, socklen_t) {
+        let wantLen = socklen_t((transport == .v4) ? MemoryLayout<sockaddr_in>.size
+                                                   : MemoryLayout<sockaddr_in6>.size)
+        var out = sockaddr_storage()
+        let copyLen = min(Int(wantLen), Int(addrLen))
+        withUnsafeMutablePointer(to: &out) { dst in
+            dst.withMemoryRebound(to: UInt8.self, capacity: copyLen) { dstBytes in
+                memcpy(dstBytes, sa, copyLen)
+            }
+        }
+        return (out, wantLen)
     }
 
     /// Classify a `getaddrinfo` status code into an honest error kind.

--- a/dart_ping_ios/ios/dart_ping_ios/Sources/dart_ping_ios/PingEngine.swift
+++ b/dart_ping_ios/ios/dart_ping_ios/Sources/dart_ping_ios/PingEngine.swift
@@ -68,19 +68,28 @@ public final class PingEngine {
         public let timeout: TimeInterval  // seconds to wait for a reply
         public let ttl: Int               // outgoing hop limit (IP_TTL / IPV6_UNICAST_HOPS)
         public let family: IPFamily       // the selected family; resolved AND sent for
+        // When true (and the selected family is v4 and the host is an IPv4
+        // literal), the engine relaxes #69's pinned resolve so the platform can
+        // synthesize a NAT64 address on an IPv6-only network and reach the
+        // literal via whichever family the resolver returns (the TRANSPORT
+        // family). It never changes the caller-selected `family`
+        // (§spec:nat64-literal-synthesis / §spec:nat64-option).
+        public let nat64Synthesis: Bool
 
         public init(host: String,
                     count: Int?,
                     interval: TimeInterval,
                     timeout: TimeInterval,
                     ttl: Int,
-                    family: IPFamily) {
+                    family: IPFamily,
+                    nat64Synthesis: Bool) {
             self.host = host
             self.count = count
             self.interval = interval
             self.timeout = timeout
             self.ttl = ttl
             self.family = family
+            self.nat64Synthesis = nat64Synthesis
         }
     }
 
@@ -129,6 +138,13 @@ public final class PingEngine {
     /// passed to `sendto`.
     private var destination: sockaddr_storage?
     private var destinationLen: socklen_t = 0
+    /// The family the engine actually opens the socket / sends / parses for. For
+    /// every non-synthesis path this equals `config.family` (zero behavior
+    /// change); only the narrow NAT64 synthesis case can differ — transport may
+    /// be `.v6` (a synthesized NAT64 address) while the caller-selected
+    /// `config.family` stays `.v4` (§spec:nat64-literal-synthesis). Set during
+    /// start() after a successful resolve; touched only on stateQueue.
+    private var transportFamily: IPFamily = .v4
     private let identifier: UInt16 = UInt16(truncatingIfNeeded: getpid())
 
     private var nextSequence: UInt16 = 0        // next seq to send
@@ -171,22 +187,32 @@ public final class PingEngine {
             // 1) Resolve the host for the SELECTED family. On failure: emit the
             //    HONEST kind (unknownHost vs noRoute, classified from the
             //    getaddrinfo status) + empty summary, then stop. We NEVER resolve
-            //    the other family as a fallback (§spec:address-family-error-honesty).
-            let resolution = self.resolve(host: self.config.host, family: self.config.family)
+            //    a hostname to the other family as a fallback
+            //    (§spec:address-family-error-honesty). The ONLY relaxation is the
+            //    narrow NAT64 synthesis case (IPv4 literal, synthesis enabled,
+            //    family .v4), where the resolver may return a synthesized v6
+            //    address and the engine sends for that TRANSPORT family while the
+            //    caller-selected family stays .v4 (§spec:nat64-literal-synthesis).
+            let resolution = self.resolve(host: self.config.host,
+                                          family: self.config.family,
+                                          nat64Synthesis: self.config.nat64Synthesis)
             switch resolution {
             case let .failure(kind):
                 self.emit(.error(kind: kind, seq: nil, ip: nil))
                 self.finishWithSummaryLocked()
                 self.stopped = true
                 return
-            case let .success(addr, addrLen):
+            case let .success(addr, addrLen, transport):
                 self.destination = addr
                 self.destinationLen = addrLen
+                self.transportFamily = transport
             }
 
-            // 2) Open the unprivileged ICMP/ICMPv6 datagram socket for the family.
+            // 2) Open the unprivileged ICMP/ICMPv6 datagram socket for the
+            //    transport family (== the selected family on every non-synthesis
+            //    path; possibly v6 for a synthesized NAT64 destination).
             let fd: Int32
-            switch self.config.family {
+            switch self.transportFamily {
             case .v4:
                 fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP)
             case .v6:
@@ -207,7 +233,7 @@ public final class PingEngine {
             // v4 uses IP_RECVTTL (datum: a single u_char); v6 uses
             // IPV6_RECVHOPLIMIT (datum: an Int32) — see extractTTL.
             var on: Int32 = 1
-            switch self.config.family {
+            switch self.transportFamily {
             case .v4:
                 setsockopt(fd, IPPROTO_IP, IP_RECVTTL, &on, socklen_t(MemoryLayout<Int32>.size))
             case .v6:
@@ -241,7 +267,7 @@ public final class PingEngine {
             // with ICMP(v6) Time Exceeded, which we surface as .timeToLiveExceeded.
             // v4: IP_TTL; v6: IPV6_UNICAST_HOPS (both take an Int32).
             var ttlVal = Int32(self.config.ttl)
-            switch self.config.family {
+            switch self.transportFamily {
             case .v4:
                 setsockopt(fd, IPPROTO_IP, IP_TTL, &ttlVal, socklen_t(MemoryLayout<Int32>.size))
             case .v6:
@@ -285,20 +311,55 @@ public final class PingEngine {
 
     // MARK: - Host resolution
 
-    /// Outcome of resolving the host for the selected family: either a copied
-    /// destination sockaddr (in a `sockaddr_storage`) with its matching socklen,
-    /// or the HONEST error kind that classifies the failure.
+    /// Outcome of resolving the host: either a copied destination sockaddr (in a
+    /// `sockaddr_storage`) with its matching socklen AND the TRANSPORT family the
+    /// engine must open the socket / send / parse for, or the HONEST error kind
+    /// that classifies the failure. The transport family equals the requested
+    /// family on every pinned path; only the NAT64 synthesis path can return a
+    /// different one (e.g. `.v6` for a synthesized address under a `.v4`
+    /// selection — §spec:nat64-literal-synthesis).
     private enum Resolution {
-        case success(sockaddr_storage, socklen_t)
+        case success(sockaddr_storage, socklen_t, IPFamily)
         case failure(PingErrorKind)
     }
 
-    /// Resolve `host` to a destination for the SELECTED `family` using
-    /// getaddrinfo, with `ai_family` pinned to AF_INET or AF_INET6 — NEVER the
-    /// other family. The getaddrinfo status is captured and classified honestly:
-    /// a genuine name miss becomes `.unknownHost`, an address-family/route
-    /// problem becomes `.noRoute` (§spec:address-family-error-honesty).
-    private func resolve(host: String, family: IPFamily) -> Resolution {
+    /// True iff `host` parses as a bare IPv4 literal (e.g. "13.35.27.1").
+    ///
+    /// Pure/static so RunnerTests can exercise the synthesis decision without a
+    /// socket. Uses `inet_pton(AF_INET, ...)`, which succeeds ONLY for a numeric
+    /// dotted-quad — a hostname or an IPv6 literal yields 0.
+    public static func isIPv4Literal(_ host: String) -> Bool {
+        var buf = in_addr()
+        return inet_pton(AF_INET, host, &buf) == 1
+    }
+
+    /// Whether to use the NAT64 un-pinned resolve relaxation: enabled AND the
+    /// selected family is v4 AND the host is an IPv4 literal.
+    ///
+    /// Pure/static so the decision is testable without the network. This is the
+    /// SOLE gate that relaxes #69's pinned resolve; everything else keeps the
+    /// byte-for-byte family-pinned behavior (§spec:nat64-literal-synthesis).
+    public static func shouldSynthesize(family: IPFamily,
+                                        nat64Synthesis: Bool,
+                                        host: String) -> Bool {
+        return nat64Synthesis && family == .v4 && isIPv4Literal(host)
+    }
+
+    /// Resolve `host` to a destination plus the TRANSPORT family to send for.
+    ///
+    /// In the narrow NAT64 synthesis case
+    /// (`Self.shouldSynthesize(family:nat64Synthesis:host:)`) the resolve is
+    /// un-pinned so the platform can synthesize a NAT64 address on an IPv6-only
+    /// network (§spec:nat64-literal-synthesis); otherwise the resolve is pinned
+    /// to AF_INET or AF_INET6 — NEVER the other family — exactly as #69 requires.
+    /// The getaddrinfo status is classified honestly: a genuine name miss becomes
+    /// `.unknownHost`, an address-family/route problem becomes `.noRoute`
+    /// (§spec:address-family-error-honesty).
+    private func resolve(host: String, family: IPFamily, nat64Synthesis: Bool) -> Resolution {
+        if Self.shouldSynthesize(family: family, nat64Synthesis: nat64Synthesis, host: host) {
+            return resolveSynthesized(host: host)
+        }
+
         var hints = addrinfo()
         hints.ai_family = (family == .v4) ? AF_INET : AF_INET6  // pinned; never the other family
         hints.ai_socktype = SOCK_DGRAM
@@ -331,12 +392,68 @@ public final class PingEngine {
                         memcpy(dstBytes, sa, copyLen)
                     }
                 }
-                return .success(out, wantLen)
+                // Pinned path: transport family == the requested family.
+                return .success(out, wantLen, family)
             }
             node = current.pointee.ai_next
         }
         // getaddrinfo succeeded but returned no address of the selected family:
         // there is no route for this family, not a name miss.
+        return .failure(.noRoute)
+    }
+
+    /// Resolve an IPv4 literal WITHOUT pinning the address family, so the system
+    /// resolver can synthesize a NAT64 address on an IPv6-only (DNS64/NAT64)
+    /// network (and return the plain IPv4 address on dual-stack / Wi-Fi) — the
+    /// path Apple documents in "Supporting IPv6 DNS64/NAT64 Networks". We run
+    /// getaddrinfo with `ai_family = AF_UNSPEC` and deliberately do NOT set
+    /// `AI_NUMERICHOST`: that flag would short-circuit the resolver and suppress
+    /// synthesis, which is exactly the pinned behavior this path relaxes.
+    ///
+    /// We take the FIRST result whose family is AF_INET or AF_INET6 and return it
+    /// as the transport family (`.v6` for AF_INET6, else `.v4`).
+    ///
+    /// Honest classification (§spec:nat64-error-fallback): an IPv4 literal that
+    /// yields no routable address is a ROUTE problem, so ANY failure here
+    /// (non-zero status OR no usable address) maps to `.noRoute`, NEVER
+    /// `.unknownHost` — it is a literal, never a name miss.
+    private func resolveSynthesized(host: String) -> Resolution {
+        var hints = addrinfo()
+        hints.ai_family = AF_UNSPEC          // let the resolver synthesize / choose
+        hints.ai_socktype = SOCK_DGRAM
+        // NB: do NOT set AI_NUMERICHOST — see the doc comment above.
+
+        var result: UnsafeMutablePointer<addrinfo>?
+        let status = getaddrinfo(host, nil, &hints, &result)
+        guard status == 0, let first = result else {
+            if result != nil { freeaddrinfo(result) }
+            return .failure(.noRoute)
+        }
+        defer { freeaddrinfo(first) }
+
+        // Walk the list for the first AF_INET / AF_INET6 entry and copy its
+        // sockaddr into a sockaddr_storage with the matching socklen (same
+        // memcpy-with-min-length pattern the pinned resolve uses).
+        var node: UnsafeMutablePointer<addrinfo>? = first
+        while let current = node {
+            let fam = current.pointee.ai_family
+            if (fam == AF_INET || fam == AF_INET6), let sa = current.pointee.ai_addr {
+                let transport: IPFamily = (fam == AF_INET6) ? .v6 : .v4
+                let wantLen = socklen_t((transport == .v4) ? MemoryLayout<sockaddr_in>.size
+                                                           : MemoryLayout<sockaddr_in6>.size)
+                var out = sockaddr_storage()
+                let copyLen = min(Int(wantLen), Int(current.pointee.ai_addrlen))
+                withUnsafeMutablePointer(to: &out) { dst in
+                    dst.withMemoryRebound(to: UInt8.self, capacity: copyLen) { dstBytes in
+                        memcpy(dstBytes, sa, copyLen)
+                    }
+                }
+                return .success(out, wantLen, transport)
+            }
+            node = current.pointee.ai_next
+        }
+        // Resolved but no usable IPv4/IPv6 address: a route problem for this
+        // literal, not a name miss.
         return .failure(.noRoute)
     }
 
@@ -413,9 +530,11 @@ public final class PingEngine {
         nextSequence = nextSequence &+ 1
 
         let nowMicros = Self.nowMicros()
-        // Build the echo for the selected family (ICMP for v4, ICMPv6 for v6).
+        // Build the echo for the TRANSPORT family (ICMP for v4, ICMPv6 for v6) —
+        // == the selected family except in the NAT64 synthesis case, where we
+        // send ICMPv6 to the synthesized address (§spec:nat64-literal-synthesis).
         let packet: Data
-        switch config.family {
+        switch transportFamily {
         case .v4:
             packet = ICMPPacket.echoRequest(identifier: identifier,
                                             sequence: seq,
@@ -491,8 +610,10 @@ public final class PingEngine {
     /// until the socket is closed. Each well-formed Echo Reply is handed to the
     /// state queue for matching.
     private func receiveLoop(fd: Int32) {
-        // The family is fixed for the whole run; capture it once.
-        let family = config.family
+        // The transport family is fixed for the whole run; capture it once. It
+        // drives strip/parse and equals the selected family except in the NAT64
+        // synthesis case (§spec:nat64-literal-synthesis).
+        let family = transportFamily
 
         // Buffers reused across iterations.
         let bufferSize = 1500
@@ -578,11 +699,11 @@ public final class PingEngine {
         // sequence and report it as a TTL-exceeded error for that seq; this is
         // NOT a successful reply (no receivedCount / RTT contribution). The
         // message type and quoted-packet layout differ by family.
-        let timeExceededType: UInt8 = (config.family == .v4) ? ICMPType.timeExceeded
-                                                             : ICMPv6Type.timeExceeded
+        let timeExceededType: UInt8 = (transportFamily == .v4) ? ICMPType.timeExceeded
+                                                               : ICMPv6Type.timeExceeded
         if let first = packet.first, first == timeExceededType {
             let parsedSeq: UInt16?
-            switch config.family {
+            switch transportFamily {
             case .v4:
                 parsedSeq = ICMPPacket.parseTimeExceededOriginalSequence(packet)
             case .v6:
@@ -605,7 +726,7 @@ public final class PingEngine {
         }
 
         let reply: ICMPPacket.EchoReply?
-        switch config.family {
+        switch transportFamily {
         case .v4:
             reply = ICMPPacket.parseEchoReply(packet)
         case .v6:

--- a/dart_ping_ios/ios/dart_ping_ios/Sources/dart_ping_ios/PingEngine.swift
+++ b/dart_ping_ios/ios/dart_ping_ios/Sources/dart_ping_ios/PingEngine.swift
@@ -30,6 +30,19 @@
 import Foundation
 import Darwin
 
+// RFC 3542 IPv6 hop-limit socket options. Darwin gates these constants behind
+// the `__APPLE_USE_RFC_3542` macro in <netinet6/in6.h>, so the Clang importer
+// does NOT expose them to Swift by default — referencing `IPV6_RECVHOPLIMIT` /
+// `IPV6_HOPLIMIT` directly fails to compile ("cannot find in scope"). Their
+// ABI-stable Darwin values are therefore used directly, the same workaround the
+// engine already applies to the un-imported ICMP6_FILTER_SETBLOCKALL/SETPASS
+// macros. The kernel honors the setsockopt option and tags the delivered cmsg
+// with these numeric values regardless of header visibility.
+//   IPV6_RECVHOPLIMIT (37): setsockopt toggle to deliver the hop limit as a cmsg
+//   IPV6_HOPLIMIT     (47): cmsg_type of the delivered hop-limit ancillary datum
+private let kIPV6_RECVHOPLIMIT: Int32 = 37
+private let kIPV6_HOPLIMIT: Int32 = 47
+
 /// Error kinds this engine can report: per-probe timeouts, TTL/hop-limit
 /// exceeded by an intermediate hop, the run-level "no reply" (nothing came back
 /// for the whole run), host-resolution failures, address-family/route failures
@@ -237,7 +250,7 @@ public final class PingEngine {
             case .v4:
                 setsockopt(fd, IPPROTO_IP, IP_RECVTTL, &on, socklen_t(MemoryLayout<Int32>.size))
             case .v6:
-                setsockopt(fd, IPPROTO_IPV6, IPV6_RECVHOPLIMIT, &on, socklen_t(MemoryLayout<Int32>.size))
+                setsockopt(fd, IPPROTO_IPV6, kIPV6_RECVHOPLIMIT, &on, socklen_t(MemoryLayout<Int32>.size))
 
                 // Restrict the ICMPv6 socket to the message types we actually
                 // handle: echo reply (129) and time exceeded (3). Without a
@@ -943,7 +956,7 @@ public final class PingEngine {
                 // unlike the v4 single-byte u_char — read the full width, but
                 // only after confirming the cmsg actually carries those 4 bytes.
                 if current.pointee.cmsg_level == IPPROTO_IPV6,
-                   current.pointee.cmsg_type == IPV6_HOPLIMIT,
+                   current.pointee.cmsg_type == kIPV6_HOPLIMIT,
                    let data = cmsgData(current,
                                        readableBytes: MemoryLayout<Int32>.size,
                                        in: &msg) {

--- a/dart_ping_ios/lib/dart_ping_ios.dart
+++ b/dart_ping_ios/lib/dart_ping_ios.dart
@@ -20,6 +20,7 @@ class DartPingIOS implements Ping {
     this._timeout,
     this._ttl,
     this._ipVersion,
+    this._nat64Synthesis,
   ) : _id = _generateId() {
     // Enforce the literal/family guard on direct construction too, not only via
     // the `Ping(...)` factory, so a mismatched literal fails fast with the same
@@ -43,8 +44,17 @@ class DartPingIOS implements Ping {
     IpVersion ipVersion,
     PingParser? parser,
     Encoding encoding,
+    bool nat64Synthesis,
   ) {
-    return DartPingIOS(host, count, interval, timeout, ttl, ipVersion);
+    return DartPingIOS(
+      host,
+      count,
+      interval,
+      timeout,
+      ttl,
+      ipVersion,
+      nat64Synthesis,
+    );
   }
 
   /// MethodChannel used to start/stop native ping runs.
@@ -71,6 +81,12 @@ class DartPingIOS implements Ping {
   final int _timeout;
   final int _ttl;
   final IpVersion _ipVersion;
+
+  /// The NAT64/DNS64 address-synthesis option (§spec:nat64-option), forwarded
+  /// to the native engine over the method channel. Default-on. The native
+  /// engine begins honoring it in a later batch (#52-2); the Dart bridge
+  /// defines and transmits the wire field here.
+  final bool _nat64Synthesis;
 
   /// Unique identifier for this run, used to demultiplex shared events.
   final String _id;
@@ -143,6 +159,10 @@ class DartPingIOS implements Ping {
       // ('ipv4' / 'ipv6'). Native family-faithful resolution lands in a
       // later batch (#69-3); the Dart bridge defines the wire field here.
       'ipVersion': _ipVersion.name,
+      // The NAT64/DNS64 synthesis option (§spec:nat64-option). The native
+      // engine begins honoring it in a later batch (#52-2); the wire field is
+      // defined and sent here.
+      'nat64Synthesis': _nat64Synthesis,
     });
   }
 

--- a/dart_ping_ios/lib/src/ping_event_mapper.dart
+++ b/dart_ping_ios/lib/src/ping_event_mapper.dart
@@ -40,6 +40,18 @@ PingEvent? mapNativeEvent(Map<dynamic, dynamic> event) {
       // PingError.fromMap reads `seq`/`ip`/`message`/`error`, so a per-probe
       // timeout / TTL-exceeded error is a single PingError that identifies its
       // own probe.
+      //
+      // This is also the seam where NAT64 synthesis failure surfaces honestly
+      // (§spec:nat64-error-fallback): when the native engine cannot synthesize
+      // or route an IPv4 literal on an IPv6-only network it emits
+      // `error:"No Route"`, which PingError.fromMap → ErrorType.fromMessage maps
+      // to the honest, branchable ErrorType.noRoute — never a phantom
+      // ErrorType.unknownHost for a literal, and never a silent drop or hang.
+      // A genuine name-resolution failure still arrives as `error:"Unknown Host"`
+      // → ErrorType.unknownHost; any unrecognized message falls back to
+      // ErrorType.unknown (§spec:address-family-error-honesty). The error event
+      // is forwarded like any other event — only the terminal summary closes
+      // the stream — so an error is delivered, not lost.
       return PingError.fromMap(map);
     case 'summary':
       // The platform codec delivers the nested `errors` entries as

--- a/dart_ping_ios/test/concurrent_isolation_test.dart
+++ b/dart_ping_ios/test/concurrent_isolation_test.dart
@@ -107,7 +107,7 @@ void main() {
         () async {
       // Run A -> a.example: distinct seq/ttl/time/ip, AND carries ONE error
       // (a requestTimedOut on seq=2). Its summary therefore records that error.
-      final pingA = DartPingIOS('a.example', 2, 1, 5, 64, IpVersion.ipv4);
+      final pingA = DartPingIOS('a.example', 2, 1, 5, 64, IpVersion.ipv4, true);
       final receivedA = <PingEvent>[];
       final doneA = Completer<void>();
       pingA.stream.listen(receivedA.add, onDone: doneA.complete);
@@ -115,7 +115,7 @@ void main() {
       // Run B -> b.example: deliberately DIFFERENT ttl/time/ip so any swap or
       // bleed from A is detectable. Run B has NO error, so its summary's error
       // list must stay empty — any error-list bleed from A is detectable.
-      final pingB = DartPingIOS('b.example', 2, 1, 5, 53, IpVersion.ipv4);
+      final pingB = DartPingIOS('b.example', 2, 1, 5, 53, IpVersion.ipv4, true);
       final receivedB = <PingEvent>[];
       final doneB = Completer<void>();
       pingB.stream.listen(receivedB.add, onDone: doneB.complete);
@@ -280,12 +280,12 @@ void main() {
       // own events and close on its own summary. We assert BOTH directions:
       // A's lone event must not be lost in B's noise, AND A's event must not
       // bleed into B.
-      final pingA = DartPingIOS('a.example', 1, 1, 5, 64, IpVersion.ipv4);
+      final pingA = DartPingIOS('a.example', 1, 1, 5, 64, IpVersion.ipv4, true);
       final receivedA = <PingEvent>[];
       final doneA = Completer<void>();
       pingA.stream.listen(receivedA.add, onDone: doneA.complete);
 
-      final pingB = DartPingIOS('b.example', 1, 1, 5, 64, IpVersion.ipv4);
+      final pingB = DartPingIOS('b.example', 1, 1, 5, 64, IpVersion.ipv4, true);
       final receivedB = <PingEvent>[];
       final doneB = Completer<void>();
       pingB.stream.listen(receivedB.add, onDone: doneB.complete);

--- a/dart_ping_ios/test/dart_ping_ios_test.dart
+++ b/dart_ping_ios/test/dart_ping_ios_test.dart
@@ -159,6 +159,29 @@ void main() {
     expect(args['nat64Synthesis'], false);
   });
 
+  test(
+      'the on/off synthesis choice threads to native start for the literal+ipv4 '
+      'path', () async {
+    // The #52-1 cases above prove the field is wired for a hostname/ipv6 call;
+    // here we pin the choice on the path synthesis actually engages — an IPv4
+    // literal under IpVersion.ipv4 — so both ends of the on/off toggle reach the
+    // native engine that decides whether to un-pin the resolve (§spec:nat64-tests).
+    Future<bool> threadedFlagFor(bool nat64) async {
+      methodCalls = [];
+      final ping = DartPingIOS('13.35.27.1', 1, 1, 2, 64, IpVersion.ipv4, nat64);
+      final sub = ping.stream.listen((_) {});
+      addTearDown(sub.cancel);
+      await pumpEventQueue();
+      final args = Map<String, dynamic>.from(callNamed('start').arguments as Map);
+      return args['nat64Synthesis'] as bool;
+    }
+
+    // ON -> the engine is told it may synthesize a NAT64 path for the literal.
+    expect(await threadedFlagFor(true), isTrue);
+    // OFF -> the engine is told to take the raw, family-pinned path (no synthesis).
+    expect(await threadedFlagFor(false), isFalse);
+  });
+
   test('forwards mapped events and closes after the terminal summary',
       () async {
     final ping = DartPingIOS('host', 2, 1, 2, 64, IpVersion.ipv4, true);

--- a/dart_ping_ios/test/dart_ping_ios_test.dart
+++ b/dart_ping_ios/test/dart_ping_ios_test.dart
@@ -160,12 +160,16 @@ void main() {
   });
 
   test(
-      'the on/off synthesis choice threads to native start for the literal+ipv4 '
-      'path', () async {
-    // The #52-1 cases above prove the field is wired for a hostname/ipv6 call;
-    // here we pin the choice on the path synthesis actually engages — an IPv4
-    // literal under IpVersion.ipv4 — so both ends of the on/off toggle reach the
-    // native engine that decides whether to un-pin the resolve (§spec:nat64-tests).
+      'the on/off nat64Synthesis flag threads to native start for an '
+      'IPv4-literal + ipv4 call', () async {
+    // Scope of THIS test: the Dart bridge forwards the flag verbatim for the
+    // IPv4-literal + IpVersion.ipv4 argument shape (both on and off), so the
+    // native engine receives the choice it needs. It does NOT — and cannot —
+    // exercise the synthesis DECISION itself: the bridge passes the flag through
+    // unchanged regardless of host/family, so this would still pass if the engine
+    // ignored it. The actual un-pin-vs-pin decision and the routable-address
+    // selection are covered offline on the native side by RunnerTests
+    // (`shouldSynthesize`, `synthesizedTransport`) (§spec:nat64-tests).
     Future<bool> threadedFlagFor(bool nat64) async {
       methodCalls = [];
       final ping = DartPingIOS('13.35.27.1', 1, 1, 2, 64, IpVersion.ipv4, nat64);

--- a/dart_ping_ios/test/dart_ping_ios_test.dart
+++ b/dart_ping_ios/test/dart_ping_ios_test.dart
@@ -137,7 +137,26 @@ void main() {
     expect(args['timeout'], 5);
     expect(args['ttl'], 64);
     expect(args['ipVersion'], 'ipv6');
+    // The 8th positional arg (nat64Synthesis) is true here, proving the
+    // default-on option threads onto the native `start` arguments
+    // (§spec:nat64-tests).
+    expect(args['nat64Synthesis'], true);
     expect(args['id'], isNotNull);
+  });
+
+  test('disabling nat64Synthesis threads the raw-path signal to native start',
+      () async {
+    // With the nat64Synthesis positional set to false, the bridge must forward
+    // `nat64Synthesis: false` so the native engine takes the raw, family-pinned
+    // path with no IPv6 synthesis (§spec:nat64-tests).
+    final ping = DartPingIOS('example.com', 3, 1, 5, 64, IpVersion.ipv6, false);
+    final sub = ping.stream.listen((_) {});
+    addTearDown(sub.cancel);
+    await pumpEventQueue();
+
+    final start = callNamed('start');
+    final args = Map<String, dynamic>.from(start.arguments as Map);
+    expect(args['nat64Synthesis'], false);
   });
 
   test('forwards mapped events and closes after the terminal summary',

--- a/dart_ping_ios/test/dart_ping_ios_test.dart
+++ b/dart_ping_ios/test/dart_ping_ios_test.dart
@@ -66,39 +66,39 @@ void main() {
       methodCalls.firstWhere((c) => c.method == name);
 
   test('command describes the native engine', () {
-    final ping = DartPingIOS('host', 1, 1, 2, 64, IpVersion.ipv4);
+    final ping = DartPingIOS('host', 1, 1, 2, 64, IpVersion.ipv4, true);
     expect(ping.command, contains('native Swift ICMP engine'));
   });
 
   group('direct construction enforces the address-family guard', () {
     test('an IPv4 literal with IpVersion.ipv6 throws ArgumentError', () {
       expect(
-        () => DartPingIOS('1.2.3.4', 1, 1, 2, 64, IpVersion.ipv6),
+        () => DartPingIOS('1.2.3.4', 1, 1, 2, 64, IpVersion.ipv6, true),
         throwsArgumentError,
       );
     });
 
     test('an IPv6 literal with IpVersion.ipv4 throws ArgumentError', () {
       expect(
-        () => DartPingIOS('::1', 1, 1, 2, 64, IpVersion.ipv4),
+        () => DartPingIOS('::1', 1, 1, 2, 64, IpVersion.ipv4, true),
         throwsArgumentError,
       );
     });
 
     test('a matching literal and a hostname construct normally', () {
       expect(
-        () => DartPingIOS('::1', 1, 1, 2, 64, IpVersion.ipv6),
+        () => DartPingIOS('::1', 1, 1, 2, 64, IpVersion.ipv6, true),
         returnsNormally,
       );
       expect(
-        () => DartPingIOS('example.com', 1, 1, 2, 64, IpVersion.ipv6),
+        () => DartPingIOS('example.com', 1, 1, 2, 64, IpVersion.ipv6, true),
         returnsNormally,
       );
     });
   });
 
   test('parser getter and setter are unsupported on iOS', () {
-    final ping = DartPingIOS('host', 1, 1, 2, 64, IpVersion.ipv4);
+    final ping = DartPingIOS('host', 1, 1, 2, 64, IpVersion.ipv4, true);
     final dummyParser = PingParser(
       responseRgx: RegExp(''),
       summaryRgx: RegExp(''),
@@ -117,13 +117,14 @@ void main() {
     DartPingIOS.register();
 
     expect(Ping.iosFactory, isNotNull);
-    final built = Ping.iosFactory!('host', 1, 1, 2, 64, IpVersion.ipv4, null, utf8);
+    final built =
+        Ping.iosFactory!('host', 1, 1, 2, 64, IpVersion.ipv4, null, utf8, true);
     expect(built, isA<DartPingIOS>());
   });
 
   test('listening starts the native run with the configured arguments',
       () async {
-    final ping = DartPingIOS('example.com', 3, 1, 5, 64, IpVersion.ipv6);
+    final ping = DartPingIOS('example.com', 3, 1, 5, 64, IpVersion.ipv6, true);
     final sub = ping.stream.listen((_) {});
     addTearDown(sub.cancel);
     await pumpEventQueue();
@@ -141,7 +142,7 @@ void main() {
 
   test('forwards mapped events and closes after the terminal summary',
       () async {
-    final ping = DartPingIOS('host', 2, 1, 2, 64, IpVersion.ipv4);
+    final ping = DartPingIOS('host', 2, 1, 2, 64, IpVersion.ipv4, true);
     final received = <PingEvent>[];
     final done = Completer<void>();
     ping.stream.listen(received.add, onDone: done.complete);
@@ -172,7 +173,7 @@ void main() {
   });
 
   test('ignores events addressed to a different run id', () async {
-    final ping = DartPingIOS('host', 1, 1, 2, 64, IpVersion.ipv4);
+    final ping = DartPingIOS('host', 1, 1, 2, 64, IpVersion.ipv4, true);
     final received = <PingEvent>[];
     ping.stream.listen(received.add);
     await pumpEventQueue();
@@ -192,7 +193,7 @@ void main() {
   });
 
   test('stop() invokes the native stop and resolves to true', () async {
-    final ping = DartPingIOS('host', null, 1, 2, 64, IpVersion.ipv4);
+    final ping = DartPingIOS('host', null, 1, 2, 64, IpVersion.ipv4, true);
     final sub = ping.stream.listen((_) {});
     addTearDown(sub.cancel);
     await pumpEventQueue();
@@ -203,7 +204,7 @@ void main() {
   });
 
   test('cancelling the subscription stops the native run', () async {
-    final ping = DartPingIOS('host', null, 1, 2, 64, IpVersion.ipv4);
+    final ping = DartPingIOS('host', null, 1, 2, 64, IpVersion.ipv4, true);
     final sub = ping.stream.listen((_) {});
     await pumpEventQueue();
     expect(methodCalls.where((c) => c.method == 'stop'), isEmpty);

--- a/dart_ping_ios/test/ping_event_mapper_test.dart
+++ b/dart_ping_ios/test/ping_event_mapper_test.dart
@@ -281,6 +281,93 @@ void main() {
     });
   });
 
+  // --- §spec:nat64-error-fallback / §spec:nat64-tests: the synthesis-failure
+  //     honest-error fallback at the Dart mapping seam --------------------------
+  //
+  // When the native engine attempts NAT64 synthesis for an IPv4 literal and the
+  // platform yields no routable address, it falls back to #69's honest typed
+  // error over the channel. These tests pin that the Dart mapper turns that
+  // native string into the honest typed PingError — NOT a phantom and NOT null —
+  // and that enabling synthesis does not disturb a normal reply's mapping
+  // (regression guards). Offline: pure native-map -> PingEvent, no live network.
+  group('NAT64 synthesis-failure fallback maps to the honest typed error', () {
+    test('a No Route synthesis failure maps to ErrorType.noRoute, not a phantom',
+        () {
+      // Synthesis could not produce a routable address for the IPv4 literal: the
+      // engine emits 'No Route'. It must surface as the honest noRoute, never a
+      // phantom unknownHost and never null (§spec:nat64-error-fallback).
+      final event = mapNativeEvent({
+        'id': 'run-1',
+        'type': 'error',
+        'error': 'No Route',
+      });
+
+      expect(event, isNotNull);
+      expect(event, isA<PingError>());
+      expect((event as PingError).error, ErrorType.noRoute);
+      expect(event.error, isNot(ErrorType.unknownHost)); // not a phantom
+    });
+
+    test('a genuine Unknown Host stays ErrorType.unknownHost', () {
+      // The reserved meaning is preserved: a real name miss is still unknownHost,
+      // so noRoute and unknownHost stay distinct under synthesis
+      // (§spec:nat64-error-fallback).
+      final event = mapNativeEvent({
+        'id': 'run-1',
+        'type': 'error',
+        'error': 'Unknown Host',
+      });
+
+      expect(event, isNotNull);
+      expect((event as PingError).error, ErrorType.unknownHost);
+    });
+  });
+
+  group('NAT64 regression guards: synthesis must not disturb working paths', () {
+    // Stand-in for a hostname / Wi-Fi / already-routable-IPv4-literal ping: a
+    // normal reply event must map exactly as before, seq/ttl/time/ip intact,
+    // with a running stats snapshot (§spec:nat64-literal-synthesis regression
+    // guard; §spec:ios-ping-behavior). Offline: pure mapping, no live network.
+    test('a normal response still maps to an intact PingResponse + stats', () {
+      final mapper = NativeEventStatsMapper();
+      final response = mapper.map({
+        'id': 'run-1',
+        'type': 'response',
+        'seq': 2,
+        'ttl': 64,
+        'time': 12000, // microseconds == 12 ms
+        'ip': '13.35.27.1',
+      }) as PingResponse;
+
+      expect(response.seq, 2);
+      expect(response.ttl, 64);
+      expect(response.time, const Duration(microseconds: 12000));
+      expect(response.ip, '13.35.27.1');
+      // The working live path still stamps the running snapshot.
+      expect(response.stats, isNotNull);
+      expect(response.stats!.sampleCount, 1);
+    });
+
+    test('the bare mapper still maps a normal response unchanged', () {
+      // The synthesis option lives entirely below this seam, so the bare
+      // native-map -> PingResponse is byte-for-byte the pre-#52 behavior.
+      final response = mapNativeEvent({
+        'id': 'run-1',
+        'type': 'response',
+        'seq': 5,
+        'ttl': 55,
+        'time': 9000,
+        'ip': '1.1.1.1',
+      }) as PingResponse;
+
+      expect(response.seq, 5);
+      expect(response.ttl, 55);
+      expect(response.time, const Duration(microseconds: 9000));
+      expect(response.ip, '1.1.1.1');
+      expect(response.stats, isNull); // bare mapper attaches no stats
+    });
+  });
+
   // --- NativeEventStatsMapper: the native-result -> event/stats seam ---
   //
   // iOS round-trip statistics are computed by REUSING the core dart_ping


### PR DESCRIPTION
## What this builds

Issue #52 — **NAT64 / IPv6-only IP-literal reachability**. On iOS over an IPv6-only cellular network (NAT64/DNS64, 464XLAT), pinging a bare IPv4 literal (e.g. `13.35.27.1`) failed outright even though the same literal worked over Wi-Fi and a *hostname* worked on the same connection. This makes the IPv4 literal **succeed** by reaching the target through the platform's own NAT64 address synthesis — and where synthesis can't help, it falls back to #69's honest typed error.

The fix sits **in front of** #69, not instead of it: #69 made the failure's *error* honest; #52 adds the capability #69 declined, so the ping actually works.

### Changes
- **New `nat64Synthesis` option** on the `Ping` factory — a named bool, **default-on**, so affected callers start working with no source change; disabling it restores the prior raw, family-pinned pass-through. Threaded to the iOS engine over the method channel; a documented **no-op** on the subprocess platforms (their native `ping` does its own resolution).
- **iOS Swift engine** — for the narrow case *synthesis-on + `IpVersion.ipv4` + IPv4 literal*, the resolve is un-pinned (`getaddrinfo` `AF_UNSPEC`, no `AI_NUMERICHOST`) so the platform can return a synthesized NAT64 address; the engine sends ICMP/ICMPv6 to whichever family the resolver returns while the caller-selected `IpVersion` stays unchanged. Every other path keeps #69's byte-for-byte family-pinned resolve. When the resolver returns both a synthesized IPv6 and the original IPv4 literal, the engine **prefers the routable IPv6 (NAT64)** address rather than committing to whichever sorted first.
- **Honest-error fallback** — when synthesis yields no routable address, the consumer receives #69's typed error (`noRoute` for an address-family/route failure, `unknownHost` reserved for a genuine name miss); never a phantom `unknownHost`, never a silent hang. The synchronous literal-vs-family `ArgumentError` is untouched.

### §spec sections now complete
- `§spec:nat64-option` — default-on `nat64Synthesis`, consistent presence + no-op on subprocess platforms
- `§spec:nat64-literal-synthesis` — un-pinned resolve + routable-family (IPv6-preferred) send on iOS
- `§spec:nat64-error-fallback` — synthesis-first, #69 honest typed error second; `ArgumentError`/`IpVersion` invariants preserved
- `§spec:nat64-tests` — offline seams (option threading, synthesis decision, address selection, honest-error mapping); live leg is an on-device acceptance step

## Integration test path for the reviewer
1. `cd dart_ping && dart analyze --fatal-infos && dart test -x live` — core suite incl. the `nat64Synthesis` subprocess no-op guard (`params`/`command` unchanged).
2. `cd dart_ping_ios && flutter analyze && flutter test` — bridge threading + event-mapping seams.
3. **macOS only** (the one gate not runnable on Linux): `cd dart_ping_ios/example && flutter build ios --simulator --no-codesign && cd ios && xcodebuild test -workspace Runner.xcworkspace -scheme Runner -only-testing:RunnerTests` — compiles the native engine and runs the `shouldSynthesize` / `isIPv4Literal` / `synthesizedTransport` / honest-error XCTest seams.
4. **On-device acceptance (manual, not CI):** on an iOS device on an IPv6-only cellular network, run the example app pinging an IPv4 literal (e.g. `13.35.27.1`) with `IpVersion.ipv4`; expect replies + RTTs + a normal summary (parity with Wi-Fi). Disable `nat64Synthesis` to observe the prior raw failure surface as a `noRoute`.

## Review note
An automated code review was already completed in the kandev Review step — see this task's **plan artifact** ("Code review — NAT64 IPv6-only IP-literal reachability"). All findings (one robustness gap, two test-coverage gaps, two cleanups) were resolved in `fix(#52): address code-review findings from the review gate`, and re-verified. Per the workflow, **do not** re-run code review on this PR.

> ⚠️ The native Swift (`ios-swift` job) is not runnable on the Linux planning host; it was hand-verified for behavior-equivalence, compile-correctness, and memory-safety, and must go green on macOS CI before merge.
