### PR TITLE
feat: run CI on PRs to develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,12 @@
 name: CI
 
-# Runs on pull requests targeting main. `main` is protected and cannot be
-# pushed to directly, so every change lands through a PR that these checks
-# gate. workflow_dispatch allows a manual run from the Actions tab.
+# Runs on pull requests targeting main and develop. Both branches are
+# protected and cannot be pushed to directly, so every change lands through a
+# PR that these checks gate. workflow_dispatch allows a manual run from the
+# Actions tab.
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   workflow_dispatch:
 
 concurrency:

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,6 +1,6 @@
 # Requirements
 
-This document tracks eight areas of work:
+This document tracks nine areas of work:
 
 1. **iOS SPM migration (#73)** — *shipped in `dart_ping_ios` 5.0.0.*
    Replace the `flutter_icmp_ping` dependency with a native Swift ICMP
@@ -53,6 +53,17 @@ This document tracks eight areas of work:
    behind an explicit option that is enabled by default — extending the
    #69 scope boundary, which made the error honest but declined to make
    the ping work. Captured in the `§req:nat64-*` sections at the end.
+9. **Windows interface-listing round-trip contract (#85)** — the
+   interface-selection helper (#72) promised a listed interface could be
+   "passed back into a `Ping`," and a test read that as *every interface
+   name* round-tripping on *every* platform. That is false on Windows by
+   the package's own design: Windows `ping` binds only by source address
+   and a bare interface name is rejected. Once CI ran the core suite on a
+   real Windows host, the contradiction turned the Windows check red. Make
+   the round-trip contract honest per platform — the source **address**
+   round-trips everywhere, the **name** only where the OS binds by name —
+   without changing any platform's runtime behavior. Captured in the
+   `§req:windows-roundtrip-*` sections at the end.
 
 ---
 
@@ -1390,3 +1401,138 @@ mechanism is decided:
   Confirming that synthesis does not change the validated family or
   disturb the literal-vs-family `ArgumentError`
   (`§spec:address-family-mismatch-validation`).
+
+---
+
+# Windows interface-listing round-trip contract (#85)
+
+A clarification, not a new feature. The interface-selection work (#72,
+`§req:interface-*`) shipped a nice-to-have helper that lists the host's
+network interfaces so a developer can "pass one back into a `Ping`." An
+automated test read that promise as *every interface name round-trips
+into a `Ping` on every platform* — an assumption the package itself
+contradicts on Windows. The contradiction stayed hidden until the
+cross-OS CI matrix ran the core suite on a real Windows host, where it
+turned the Windows check red. This area makes the round-trip contract
+honest per platform.
+
+## Windows round-trip — problem statement §req:windows-roundtrip-problem-statement
+
+The affected party here is the **maintainer** (and any contributor whose
+PR is blocked by a red gate), and secondarily the **cross-platform
+developer** who relies on the interface-listing helper's promise.
+
+The interface-selection feature (#72) established two facts that are both
+correct and both already documented in `§req:interface-success-criteria`:
+
+- The listing helper returns the host's interfaces, "enough to identify
+  and pass one back into a `Ping`."
+- On Windows, the OS `ping` binds **only by source address** (`-S
+  <address>`), never by interface name, so passing a **bare interface
+  name** on Windows produces a clear, catchable error rather than silently
+  pinging the default route.
+
+A test encoded a *stronger* reading of the first fact than the second
+allows: that every listed interface's **name** can be fed back into
+`Ping(interface: name)` and construct without throwing, on **every**
+platform. That holds on Linux/Android and macOS, whose `ping` binds by
+name. It is **false on Windows** — by the package's own deliberate
+design, a bare name is rejected.
+
+The contradiction was invisible while CI gated only PRs to `main` on the
+existing matrix; it surfaced once the core suite ran on an actual Windows
+runner (the cross-OS matrix from #77, extended to PRs targeting `develop`
+in #85). The Windows runner reports a named NIC (`"Ethernet 3"`); the
+round-trip test feeds that name back into a Windows `Ping`, which
+**correctly** throws `UnimplementedError` ("Windows ping binds only by
+source address, not by interface name…"), and the test fails with
+`195 tests passed, 1 failed`.
+
+The user-visible problem is therefore a **red Windows CI check that
+blocks merges**, caused not by wrong Windows behavior but by a test
+asserting a guarantee the package never offered on Windows. The defect is
+in the *contract/expectation*, not in Windows ping behavior. Left
+unaddressed it is both **frequent** (every PR re-runs the gate) and
+**expensive** (a red required check stops the merge queue and erodes
+trust in the matrix), while masking the fact that Windows is, in truth,
+behaving exactly as specified.
+
+## Windows round-trip — success criteria §req:windows-roundtrip-success-criteria
+
+Observable, verifiable outcomes:
+
+- **The Windows core CI check passes.** The `core (windows-latest)` job
+  goes green on a host that reports named NICs, so the cross-OS gate is
+  green on Linux, Windows, and macOS together. *(must-have)*
+- **The round-trip promise is honest per platform.** A listed interface's
+  **source address** round-trips into a `Ping` — constructs without
+  throwing — on **every** supported desktop platform. A listed interface's
+  **name** round-trips **only** where the OS binds by name (Linux/Android,
+  macOS); on Windows, passing a listed **name** is rejected with the
+  clear, catchable error already specified, and passing the listed
+  **address** works. *(must-have)*
+- **Windows runtime behavior is unchanged.** Source-address selection
+  still binds on Windows; a bare interface name is still rejected loudly
+  (never a silent default-route ping). No platform's runtime behavior
+  changes — only the contract and the test's expectation do. *(must-have —
+  consistency with `§req:interface-success-criteria`.)*
+- **The check is deterministic across runners.** The round-trip is
+  verified by automated tests that pass on a real Windows host and do
+  **not** depend on which interface names or addresses a particular runner
+  happens to report. *(must-have — the original failure was runner-NIC
+  dependent.)*
+
+## Windows round-trip — user stories §req:windows-roundtrip-user-stories
+
+- As a maintainer, I want the Windows CI check to pass so that merges
+  aren't blocked by a test asserting behavior the package intentionally
+  does not have.
+- As a cross-platform developer using the listing helper, I want "pass one
+  back into a `Ping`" to be true everywhere — I can rely on a listed
+  interface's **source address** round-tripping on any desktop platform,
+  and I understand the **name** works only where the OS binds by name.
+- As a Windows developer enumerating interfaces, I want a clear, working
+  path (select by the source address) and a clear error if I pass a name,
+  rather than a confusing CI failure or a silent wrong-interface ping.
+
+## Windows round-trip — quality attributes §req:windows-roundtrip-quality-attributes
+
+- **Cross-platform honesty:** the documented round-trip contract matches
+  actual per-platform behavior; there is no "green everywhere" claim that
+  is false on one OS (`§req:interface-quality-attributes` —
+  cross-platform predictability).
+- **Determinism:** the verifying test does not depend on host-specific NIC
+  names or addresses, so it is reproducible on any runner.
+- **Backward compatibility:** no change to the public API and no change to
+  runtime behavior on Linux/Android, macOS, or Windows — only the contract
+  wording and the test expectation change.
+- **Testability:** the corrected round-trip is exercised on a real Windows
+  host in CI, so the same contradiction cannot silently return.
+
+## Windows round-trip — constraints §req:windows-roundtrip-constraints
+
+- **Refinement, not new capability.** This refines
+  `§req:interface-success-criteria` ("Available interfaces can be listed"
+  and "Windows honors the source-address form"). Windows keeps **rejecting
+  bare names**; the fix corrects the contract and the test, it does not add
+  Windows name binding.
+- **No new public API, no behavior change** on any platform. Scope is the
+  listing↔selection round-trip contract and the tests that assert it.
+- **Decided in discovery:** the round-trippable handle is the source
+  **address** universally; the **name** only where the OS binds by name.
+  Making Windows resolve a name → source address (so names round-trip
+  everywhere) is **explicitly out of scope**.
+- **Traceability:** surfaced by issue **#85** (the CI work that ran the
+  core suite on a Windows host); relates to the cross-OS matrix (#77) and
+  interface selection (#72). The separate Windows IPv6 gap (#71) is **not**
+  in scope.
+
+## Windows round-trip — priorities §req:windows-roundtrip-priorities
+
+- **Must-have:** the Windows core CI check green; an honest per-platform
+  round-trip contract (address everywhere, name only where bound by name);
+  Windows name-rejection / address-acceptance unchanged; a deterministic
+  test independent of host NIC names and addresses.
+- **Nice-to-have:** a documentation note on the listing helper explaining
+  that on Windows you pass back a listed interface's **source address**,
+  not its name.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,6 +1,6 @@
 # Requirements
 
-This document tracks eight areas of work:
+This document tracks nine areas of work:
 
 1. **iOS SPM migration (#73)** — *shipped in `dart_ping_ios` 5.0.0.*
    Replace the `flutter_icmp_ping` dependency with a native Swift ICMP
@@ -53,6 +53,15 @@ This document tracks eight areas of work:
    behind an explicit option that is enabled by default — extending the
    #69 scope boundary, which made the error honest but declined to make
    the ping work. Captured in the `§req:nat64-*` sections at the end.
+9. **CI on PRs to `develop`** — the repository follows a gitflow model
+   where feature branches merge into a `develop` integration branch, which
+   periodically merges to `main` for release. The existing CI
+   (`§spec:ci`) gates only PRs to `main`, so a feature branch merges into
+   `develop` with no checks and breakage accumulates there unseen until the
+   `develop`→`main` release PR runs CI — late, batched, and hard to
+   attribute. Extend CI so the same gate runs on PRs targeting `develop`,
+   and protect `develop` like `main`. Captured in the `§req:ci-develop-*`
+   sections at the end.
 
 ---
 
@@ -1390,3 +1399,123 @@ mechanism is decided:
   Confirming that synthesis does not change the validated family or
   disturb the literal-vs-family `ArgumentError`
   (`§spec:address-family-mismatch-validation`).
+
+---
+
+# CI on PRs to `develop`
+
+## CI on develop — problem statement §req:ci-develop-problem-statement
+
+The user is the maintainer of this two-package repository
+(`dart_ping` + `dart_ping_ios`), working in a gitflow-style branching
+model: feature branches merge into a long-lived `develop` integration
+branch, and `develop` periodically merges into `main` to cut a release.
+
+The existing continuous-integration gate (`§spec:ci`) triggers only on
+pull requests targeting `main`. In a gitflow model that is the wrong
+checkpoint: by the time code reaches a `develop`→`main` PR it has already
+been integrated on `develop`, often across many feature merges. So today a
+feature branch can merge into `develop` having never run the suite, and any
+breakage it introduces sits on `develop` unnoticed until the release PR
+finally runs CI.
+
+That makes failures **late, batched, and hard to attribute**: the release
+PR goes red, but the red reflects the combined effect of everything merged
+since the last release, not the one change that caused it. The maintainer
+then has to bisect after the fact instead of seeing a clean red check on
+the individual feature PR that introduced the problem. The integration
+branch — the very place a gitflow model expects to always be in a
+known-good, releasable state — has no guard keeping it that way.
+
+The fix the maintainer wants is to move the gate earlier: run the same
+checks on every PR into `develop`, and protect `develop` so nothing lands
+there without passing them — so `develop` stays releasable and breakage is
+caught on the PR that caused it.
+
+## CI on develop — success criteria §req:ci-develop-success-criteria
+
+Observable outcomes a tester can verify from the repository's GitHub
+surface (Actions tab, PR checks, branch-protection settings):
+
+- **Opening a PR that targets `develop` triggers CI.** The same automated
+  suites that run on a PR to `main` start automatically on a PR whose base
+  is `develop`, with no manual action. *(must-have)*
+- **The checks are at full parity with the `main` gate.** A PR to
+  `develop` runs the identical set of jobs a PR to `main` runs today — the
+  core `dart_ping` suite on Linux, Windows and macOS; the `dart_ping_ios`
+  Dart suite on Linux; the Swift `RunnerTests` suite on macOS; and the
+  informational coverage report — with the same deterministic, live-network-
+  excluded behavior. *(must-have)*
+- **A failing suite shows red on the `develop` PR.** When a change breaks a
+  gating suite, the failure is visible as a failed required check on that
+  PR, attributable to that change. *(must-have)*
+- **`develop` cannot be changed except through a passing PR.** Direct
+  pushes to `develop` are rejected, and a PR into `develop` cannot merge
+  until its required checks are green — mirroring the protection already on
+  `main`. *(must-have)*
+- **The `main` gate is unchanged.** PRs to `main` continue to trigger and
+  gate exactly as before; adding the `develop` trigger removes or weakens
+  nothing on the `main` path. *(must-have)*
+- **A manual run is still possible.** The workflow can still be dispatched
+  manually from the Actions tab (the existing `workflow_dispatch` path is
+  preserved). *(nice-to-have)*
+
+## CI on develop — user stories §req:ci-develop-user-stories
+
+- As the maintainer, I want CI to run automatically when a feature branch
+  opens a PR into `develop` so that I see breakage on the PR that caused it
+  rather than later on the release PR.
+- As the maintainer, I want `develop` protected so that no change can land
+  on it without a green run, keeping the integration branch releasable.
+- As a contributor, I want my PR into `develop` to show the same checks as a
+  PR into `main` so that "green on develop" already means "ready for
+  release," with no surprises at the `develop`→`main` step.
+- As the maintainer, I want the `develop`→`main` release PR to be
+  predictable — green because everything merged into `develop` was already
+  green — instead of a batched red I have to bisect.
+
+## CI on develop — quality attributes §req:ci-develop-quality-attributes
+
+- **Determinism (carried over from `§spec:ci`):** the gating checks on
+  `develop` stay reproducible — live ICMP round-trips to external hosts are
+  excluded, exactly as on the `main` gate. A required check that flaps on a
+  network blip trains the maintainer to ignore it.
+- **Parity / single source of truth:** the `develop` gate is the *same*
+  checks as the `main` gate, not a divergent copy that can drift. "Green on
+  develop" and "green on main" mean the same thing.
+- **Low maintenance:** extending the trigger should not duplicate job
+  definitions; the two branch targets share one workflow so there is one
+  place to change a job.
+- **Cost is acceptable:** running the full matrix on both `develop` PRs and
+  the later `develop`→`main` PR is an accepted cost — confidence on the
+  integration branch is worth the extra runner minutes. (Runner cost is not
+  a constraint for this work.)
+
+## CI on develop — constraints §req:ci-develop-constraints
+
+- **Full parity, not a lighter subset.** The decision is to run the
+  complete `main` job set on `develop` PRs (core OS matrix + iOS Dart + iOS
+  Swift + coverage), not a reduced fast gate.
+- **`develop` is branch-protected like `main`.** Required green checks
+  before merge, no direct pushes. Branch protection is a GitHub repository
+  setting outside the workflow file; it is part of this requirement's
+  "done" even though it is configured in repo settings rather than in
+  `.github/workflows/ci.yml`.
+- **The deterministic / live-network exclusion of `§spec:ci` is
+  preserved** — the `develop` gate inherits it because it is the same
+  workflow, not a separate definition.
+- **No change to the `main` trigger or its protection.** This work only
+  adds `develop` as an additional gated target.
+- **Builds on the existing `§spec:ci` workflow** (`.github/workflows/ci.yml`)
+  rather than introducing a new pipeline.
+
+## CI on develop — priorities §req:ci-develop-priorities
+
+- **Must-have:** CI triggers automatically on PRs to `develop`; full
+  job parity with the `main` gate; failures visible and attributable on the
+  `develop` PR; `develop` branch-protected so merges require green checks;
+  the `main` gate unchanged.
+- **Nice-to-have:** the manual `workflow_dispatch` path remains available.
+- **Out of scope:** any lighter/faster subset gate, coverage-threshold
+  enforcement, changes to which tests are live-excluded, and any change to
+  the `main` pipeline beyond adding the `develop` target.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,67 +1,67 @@
 # Requirements
 
-This document tracks nine areas of work:
+This document tracks the following areas of work:
 
-1. **iOS SPM migration (#73)** — *shipped in `dart_ping_ios` 5.0.0.*
-   Replace the `flutter_icmp_ping` dependency with a native Swift ICMP
-   engine and ship under Swift Package Manager. Captured in the
-   `§req:problem-statement` … `§req:priorities` sections below.
-2. **Maintenance & modernization refresh** — a cross-package pass to bring
-   dependencies, SDK constraints, documentation, and test coverage current,
-   and to surface bugs / security flaws / improvements across the Dart and
-   native Swift code. Captured in the `§req:refresh-*` sections.
-3. **`base_ping` stream lifecycle robustness (#76)** — fix two edge paths
-   in the core `dart_ping` stream where a consumer can hang forever
-   instead of seeing an error: an unmapped non-zero exit code, and a
-   failed process launch (e.g. a missing `ping` binary). Surfaced by the
-   Dart code audit (`§spec:code-audit`). Captured in the
-   `§req:robustness-*` sections.
-4. **IPv6 / address-family error clarity (#69)** — on IPv6-enabled
-   networks (notably mobile data), pinging an IP can fail with a
-   misleading "Unknown Host" error when the `ipv6` flag and the target's
-   address family disagree, or when the network/adapter cannot route the
-   selected family. Treat `ipv6` as an exclusive address-family selector,
-   validate obvious literal mismatches up front, and surface honest,
-   consistent errors instead of mislabeling them. Captured in the
-   `§req:ipfamily-*` sections at the end.
-5. **Interface selection (#72)** — let a developer choose which network
-   interface (by interface name or by local source address) pings
-   originate from, on the desktop platforms (Linux/Android, macOS,
-   Windows), with a nice-to-have helper to enumerate the available
-   interfaces. Captured in the `§req:interface-*` sections at the end.
-6. **Concurrent-ping isolation (#70)** — a reported defect where two or
-   more `Ping` instances run at the same time report the same round-trip
-   results instead of each host's own, first seen on Android. Fix so that
-   concurrent `Ping` instances are fully independent. Captured in the
-   `§req:concurrent-*` sections at the end.
-7. **Summary statistics (#63)** — surface the richer round-trip
-   statistics the native `ping` already prints (min / avg / max / stddev),
-   plus a mean-consecutive-delta jitter figure and packet-loss %, both in
-   the run summary and as live running stats during a run, with full
-   cross-platform parity including iOS. Delivered via a from-scratch
-   redesign of the stream's event/data classes (a sealed event union plus a
-   reusable round-trip-stats value object), folded into the
-   already-unreleased breaking `dart_ping` 10.0.0 / `dart_ping_ios` 6.0.0
-   majors. Captured in the `§req:stats-*` sections at the end.
-8. **NAT64 / IPv6-only IP-literal reachability (#52)** — on iOS over
-   cellular (mobile data), pinging a bare IPv4 literal fails outright,
-   while a hostname works and the same literal works over Wi-Fi, because
-   the carrier runs an IPv6-only (NAT64/DNS64) network that synthesizes a
-   routable address for hostnames but not for raw IP literals. Make the
-   literal ping actually succeed via the platform's NAT64 address
-   synthesis (as Apple's own guidance and third-party ping apps do),
-   behind an explicit option that is enabled by default — extending the
-   #69 scope boundary, which made the error honest but declined to make
-   the ping work. Captured in the `§req:nat64-*` sections at the end.
-9. **CI on PRs to `develop`** — the repository follows a gitflow model
-   where feature branches merge into a `develop` integration branch, which
-   periodically merges to `main` for release. The existing CI
-   (`§spec:ci`) gates only PRs to `main`, so a feature branch merges into
-   `develop` with no checks and breakage accumulates there unseen until the
-   `develop`→`main` release PR runs CI — late, batched, and hard to
-   attribute. Extend CI so the same gate runs on PRs targeting `develop`,
-   and protect `develop` like `main`. Captured in the `§req:ci-develop-*`
-   sections at the end.
+- **iOS SPM migration (#73)** — *shipped in `dart_ping_ios` 5.0.0.*
+  Replace the `flutter_icmp_ping` dependency with a native Swift ICMP
+  engine and ship under Swift Package Manager. Captured in the
+  `§req:problem-statement` … `§req:priorities` sections below.
+- **Maintenance & modernization refresh** — a cross-package pass to bring
+  dependencies, SDK constraints, documentation, and test coverage current,
+  and to surface bugs / security flaws / improvements across the Dart and
+  native Swift code. Captured in the `§req:refresh-*` sections.
+- **`base_ping` stream lifecycle robustness (#76)** — fix two edge paths
+  in the core `dart_ping` stream where a consumer can hang forever
+  instead of seeing an error: an unmapped non-zero exit code, and a
+  failed process launch (e.g. a missing `ping` binary). Surfaced by the
+  Dart code audit (`§spec:code-audit`). Captured in the
+  `§req:robustness-*` sections.
+- **IPv6 / address-family error clarity (#69)** — on IPv6-enabled
+  networks (notably mobile data), pinging an IP can fail with a
+  misleading "Unknown Host" error when the `ipv6` flag and the target's
+  address family disagree, or when the network/adapter cannot route the
+  selected family. Treat `ipv6` as an exclusive address-family selector,
+  validate obvious literal mismatches up front, and surface honest,
+  consistent errors instead of mislabeling them. Captured in the
+  `§req:ipfamily-*` sections at the end.
+- **Interface selection (#72)** — let a developer choose which network
+  interface (by interface name or by local source address) pings
+  originate from, on the desktop platforms (Linux/Android, macOS,
+  Windows), with a nice-to-have helper to enumerate the available
+  interfaces. Captured in the `§req:interface-*` sections at the end.
+- **Concurrent-ping isolation (#70)** — a reported defect where two or
+  more `Ping` instances run at the same time report the same round-trip
+  results instead of each host's own, first seen on Android. Fix so that
+  concurrent `Ping` instances are fully independent. Captured in the
+  `§req:concurrent-*` sections at the end.
+- **Summary statistics (#63)** — surface the richer round-trip
+  statistics the native `ping` already prints (min / avg / max / stddev),
+  plus a mean-consecutive-delta jitter figure and packet-loss %, both in
+  the run summary and as live running stats during a run, with full
+  cross-platform parity including iOS. Delivered via a from-scratch
+  redesign of the stream's event/data classes (a sealed event union plus a
+  reusable round-trip-stats value object), folded into the
+  already-unreleased breaking `dart_ping` 10.0.0 / `dart_ping_ios` 6.0.0
+  majors. Captured in the `§req:stats-*` sections at the end.
+- **NAT64 / IPv6-only IP-literal reachability (#52)** — on iOS over
+  cellular (mobile data), pinging a bare IPv4 literal fails outright,
+  while a hostname works and the same literal works over Wi-Fi, because
+  the carrier runs an IPv6-only (NAT64/DNS64) network that synthesizes a
+  routable address for hostnames but not for raw IP literals. Make the
+  literal ping actually succeed via the platform's NAT64 address
+  synthesis (as Apple's own guidance and third-party ping apps do),
+  behind an explicit option that is enabled by default — extending the
+  #69 scope boundary, which made the error honest but declined to make
+  the ping work. Captured in the `§req:nat64-*` sections at the end.
+- **CI on PRs to `develop`** — the repository follows a gitflow model
+  where feature branches merge into a `develop` integration branch, which
+  periodically merges to `main` for release. The existing CI
+  (`§spec:ci`) gates only PRs to `main`, so a feature branch merges into
+  `develop` with no checks and breakage accumulates there unseen until the
+  `develop`→`main` release PR runs CI — late, batched, and hard to
+  attribute. Extend CI so the same gate runs on PRs targeting `develop`,
+  and protect `develop` like `main`. Captured in the `§req:ci-develop-*`
+  sections at the end.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -697,6 +697,75 @@ deserialized one vs. its original) could land in different hash buckets,
 silently breaking `Set`/`Map` membership. The fix is small and clearly
 correct, the kind of latent defect the §spec:code-audit pass targets.
 
+## CI gates pull requests to `develop` §spec:ci-develop
+*Status: not started*
+
+The repository follows a gitflow model: feature branches merge into a
+long-lived `develop` integration branch, and `develop` periodically merges
+into `main` to cut a release (§req:ci-develop-problem-statement). The CI
+gate (§spec:ci) previously triggered only on pull requests to `main`, which
+in a gitflow model is the wrong checkpoint — a feature branch could land on
+`develop` having never run the suite, so breakage accumulated on the
+integration branch unseen until the `develop`→`main` release PR finally ran
+CI: late, batched across many merges, and hard to attribute to the change
+that caused it. This section moves the gate earlier so `develop` stays
+releasable and a failure shows on the PR that introduced it.
+
+- When a pull request targets `develop`, the CI workflow shall trigger
+  automatically — no manual action — running the same job set a pull
+  request to `main` runs (§req:ci-develop-success-criteria).
+- The jobs run on a `develop` PR shall be at full parity with the `main`
+  gate: the core `dart_ping` suite on Linux, Windows and macOS; the
+  `dart_ping_ios` Dart suite on Linux; the Swift `RunnerTests` suite on
+  macOS; and the informational coverage report — with the same
+  deterministic, live-network-excluded behavior (`dart test -x live`) the
+  `main` gate has (§spec:ci, §req:ci-develop-constraints).
+- Parity shall be structural, not a maintained copy: `develop` and `main`
+  are two triggers on **one** workflow definition, so the two gates cannot
+  drift and there is a single place to change a job
+  (§req:ci-develop-quality-attributes).
+- When a change breaks a gating suite, the failure shall be visible as a
+  failed required check on the `develop` PR, attributable to that change
+  (§req:ci-develop-success-criteria).
+- `develop` shall be branch-protected like `main`: direct pushes are
+  rejected, and a PR into `develop` cannot merge until its required checks
+  are green. This protection is a GitHub repository setting outside the
+  workflow file but is part of this section's done state
+  (§req:ci-develop-constraints).
+- Adding the `develop` trigger shall leave the `main` gate unchanged — PRs
+  to `main` continue to trigger and gate exactly as before, and `main`'s
+  protection is untouched (§req:ci-develop-success-criteria).
+- The manual `workflow_dispatch` path shall remain available
+  (§req:ci-develop-priorities, nice-to-have).
+- No lighter or faster subset gate, coverage-threshold enforcement, or
+  change to which tests are live-excluded shall be introduced
+  (§req:ci-develop-priorities, out of scope).
+
+**Why full parity rather than a lighter fast gate:** "green on `develop`"
+must mean the same thing as "green on `main`," so the `develop`→`main`
+release PR is predictable — green because everything merged into `develop`
+was already green, not a batched red the maintainer has to bisect
+(§req:ci-develop-user-stories). A divergent reduced gate would let a class
+of failure reach the release PR unguarded, defeating the purpose. Running
+the full matrix on both `develop` PRs and the later release PR is an
+accepted cost; runner minutes are not a constraint here
+(§req:ci-develop-quality-attributes).
+
+**Why one workflow with two branch targets rather than a second pipeline:**
+a copied workflow drifts — a job fixed on one path silently rots on the
+other — and the determinism guarantee of §spec:ci is inherited only if the
+`develop` gate *is* that same definition. Extending the existing
+`pull_request.branches` list keeps one source of truth and inherits the
+live-network exclusion by construction rather than by duplicated
+configuration (§req:ci-develop-constraints).
+
+**Why branch protection is in scope despite living in repo settings:** the
+problem is not just "checks run" but "nothing lands on `develop` without
+them." Triggering CI without protecting the branch would still let a red or
+unchecked change merge, leaving the integration branch unguarded — so the
+protection setting, though configured outside `.github/workflows/ci.yml`, is
+part of "done" for this capability (§req:ci-develop-problem-statement).
+
 ---
 
 # IPv6 / address-family error clarity

--- a/SPEC.md
+++ b/SPEC.md
@@ -698,7 +698,7 @@ silently breaking `Set`/`Map` membership. The fix is small and clearly
 correct, the kind of latent defect the §spec:code-audit pass targets.
 
 ## CI gates pull requests to `develop` §spec:ci-develop
-*Status: not started*
+*Status: implemented*
 
 The repository follows a gitflow model: feature branches merge into a
 long-lived `develop` integration branch, and `develop` periodically merges

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,38 +1,38 @@
 # Specification
 
-This document covers eight areas, matching REQUIREMENTS.md:
+This document covers the following areas, matching REQUIREMENTS.md:
 
-1. **iOS SPM migration (#73)** — `§spec:swift-icmp-engine` …
-   `§spec:ios-tests` below (implemented).
-2. **Maintenance & modernization refresh** — the `§spec:dependency-currency`
-   … `§spec:code-audit` sections (complete).
-3. **`base_ping` stream lifecycle robustness (#76)** —
-   `§spec:stream-lifecycle-robustness` (implemented). A focused
-   follow-up to two hang paths deferred from `§spec:code-audit`.
-4. **Continuous integration & coverage expansion (#74, #77)** — the
-   `§spec:ci` … `§spec:coverage-expansion` sections (implemented). This is
-   new work *beyond* the refresh's "fill gaps only" scope, which had
-   deliberately excluded CI (§spec:test-coverage).
-5. **IPv6 / address-family error clarity (#69)** — the
-   `§spec:ipv6-address-family-selector` …
-   `§spec:address-family-error-tests` sections (implemented). A
-   correctness-of-errors fix so address-family and routing failures stop
-   masquerading as "Unknown Host" on IPv6-enabled networks.
-6. **Interface selection (#72)** — `§spec:interface-selection` …
-   `§spec:interface-listing` at the very end (not started). An optional way
-   to pin pings to a chosen network interface or source address on the
-   subprocess platforms, with a helper to enumerate the host's interfaces.
-   Additive on top of the existing `Ping` API.
-7. **Concurrent-ping isolation (#70)** — `§spec:concurrent-isolation`
-   at the very end (implemented). A reported cross-contamination defect
-   between simultaneously-running `Ping` instances.
-8. **Summary statistics (#63)** — the `§spec:stats-event-model` …
-   `§spec:stats-tests` sections at the very end (not started). Surfaces
-   round-trip min / avg / max / stddev, jitter, and packet-loss — in the run
-   summary and live during a run, with iOS parity — via a from-scratch
-   redesign of the stream's event/data classes, folded into the unreleased
-   breaking `dart_ping` 10.0.0 / `dart_ping_ios` 6.0.0 majors. **Supersedes
-   the API-stability promises of areas 1–7.**
+- **iOS SPM migration (#73)** — `§spec:swift-icmp-engine` …
+  `§spec:ios-tests` below (implemented).
+- **Maintenance & modernization refresh** — the `§spec:dependency-currency`
+  … `§spec:code-audit` sections (complete).
+- **`base_ping` stream lifecycle robustness (#76)** —
+  `§spec:stream-lifecycle-robustness` (implemented). A focused
+  follow-up to two hang paths deferred from `§spec:code-audit`.
+- **Continuous integration & coverage expansion (#74, #77)** — the
+  `§spec:ci` … `§spec:coverage-expansion` sections (implemented). This is
+  new work *beyond* the refresh's "fill gaps only" scope, which had
+  deliberately excluded CI (§spec:test-coverage).
+- **IPv6 / address-family error clarity (#69)** — the
+  `§spec:ipv6-address-family-selector` …
+  `§spec:address-family-error-tests` sections (implemented). A
+  correctness-of-errors fix so address-family and routing failures stop
+  masquerading as "Unknown Host" on IPv6-enabled networks.
+- **Interface selection (#72)** — `§spec:interface-selection` …
+  `§spec:interface-listing` at the very end (not started). An optional way
+  to pin pings to a chosen network interface or source address on the
+  subprocess platforms, with a helper to enumerate the host's interfaces.
+  Additive on top of the existing `Ping` API.
+- **Concurrent-ping isolation (#70)** — `§spec:concurrent-isolation`
+  at the very end (implemented). A reported cross-contamination defect
+  between simultaneously-running `Ping` instances.
+- **Summary statistics (#63)** — the `§spec:stats-event-model` …
+  `§spec:stats-tests` sections at the very end (not started). Surfaces
+  round-trip min / avg / max / stddev, jitter, and packet-loss — in the run
+  summary and live during a run, with iOS parity — via a from-scratch
+  redesign of the stream's event/data classes, folded into the unreleased
+  breaking `dart_ping` 10.0.0 / `dart_ping_ios` 6.0.0 majors. **Supersedes
+  the API-stability promises of the preceding areas.**
 
 Solution-space design for issue #73 — native, Swift Package Manager
 (SPM)-compatible iOS support for `dart_ping`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2093,7 +2093,7 @@ listing↔selection round-trip contract honest per platform and proves it on a
 real Windows host, with no change to any platform's runtime behavior.
 
 ## Per-platform round-trip honesty §spec:windows-roundtrip-contract
-*Status: not started*
+*Status: implemented (Batch #85-1) — the round-trip test `dart_ping/test/interface_listing_test.dart` ("each interface has the right shape and round-trips into Ping") now branches the listed-**name** expectation on the platform's binding ability (`Platform.isWindows`): a name round-trips (`returnsNormally`) on name-binding platforms (Linux/Android, macOS) and is expected to throw the catchable `UnimplementedError` on Windows (which `PingWindows` raises at construction), while a listed source **address** round-trips (`returnsNormally`) on every desktop platform. The expectation no longer depends on which names/addresses a runner reports, so it is deterministic on any host and the `core (windows-latest)` job goes green alongside Linux and macOS. The listing helper's dartdoc, the README "Selecting a network interface" section, and the CHANGELOG note that on Windows a listed interface is passed back as its source address, not its name. No runtime, command, stream, or public-API change on any platform. Covered by network-free `dart test` (the full core suite passes `-x live`, 196 tests).*
 
 The handle a developer carries from `listNetworkInterfaces()` back into a
 `Ping(interface: …)` round-trips per the platform's actual binding ability:

--- a/SPEC.md
+++ b/SPEC.md
@@ -2065,3 +2065,122 @@ resolver outcome in → synthesized-send or typed-error out) — while the
 end-to-end reachability is verified by hand on an affected device, mirroring
 the suite's established deterministic-seam principle (§spec:ci,
 §spec:ios-tests).
+
+---
+
+# Windows interface-listing round-trip contract
+
+Solution-space design for issue #85 (`§req:windows-roundtrip-*`). A
+clarification of the interface work (#72, `§spec:interface-selection` …
+`§spec:interface-listing`), not a new capability. The listing helper
+(§spec:interface-listing) promises that what it returns "feeds straight back
+into a `Ping`'s `interface` value." A round-trip test encoded a *stronger*
+reading of that promise than the package ever offered — that *every listed
+interface's name* constructs a `Ping` without throwing on *every* platform —
+which the package contradicts on Windows by design (§spec:interface-platform-rejection:
+a bare name is rejected because Windows `ping` binds only by source address).
+
+The contradiction was invisible while the round-trip ran only on hosts whose
+`NetworkInterface.list()` happened to report addresses, and while the gate
+ran the core suite only where the assumption held. Once the cross-OS matrix
+(§spec:ci) ran the core suite on a real Windows runner — which reports a
+named NIC (e.g. `"Ethernet 3"`) — the test fed that name into a Windows
+`Ping`, the constructor correctly threw `UnimplementedError`, and the
+Windows check went red (`195 passed, 1 failed`). The defect is in the test's
+*expectation*, not in Windows behavior: Windows was doing exactly what
+§spec:interface-platform-rejection specifies. This area makes the
+listing↔selection round-trip contract honest per platform and proves it on a
+real Windows host, with no change to any platform's runtime behavior.
+
+## Per-platform round-trip honesty §spec:windows-roundtrip-contract
+*Status: not started*
+
+The handle a developer carries from `listNetworkInterfaces()` back into a
+`Ping(interface: …)` round-trips per the platform's actual binding ability:
+a listed interface's **source address** constructs a `Ping` without throwing
+on every supported desktop platform; a listed interface's **name** does so
+only where the OS `ping` binds by name (Linux/Android, macOS). On Windows a
+listed **name** is rejected with the catchable error already specified, and a
+listed **address** is accepted. Nothing about Windows runtime behavior
+changes — only the contract's wording and the test that asserts it.
+
+- A listed interface's source **address** shall round-trip — feed back into
+  `Ping('…', interface: addr)` and construct without throwing — on **every**
+  supported desktop platform (Linux/Android, macOS, Windows), because every
+  platform's `ping` can bind a source address (§req:windows-roundtrip-success-criteria
+  — round-trip honest per platform; §spec:interface-selection).
+- A listed interface's **name** shall round-trip the same way **only** on the
+  platforms whose `ping` binds by name (Linux/Android, macOS). On **Windows**,
+  passing a listed name shall be rejected by the same explicit, catchable
+  `UnimplementedError` specified in §spec:interface-platform-rejection —
+  Windows `ping` binds only by source address — never a silent default-route
+  ping (§req:windows-roundtrip-success-criteria — round-trip honest per
+  platform; §req:windows-roundtrip-constraints — Windows keeps rejecting bare
+  names).
+- Windows runtime behavior shall be unchanged: source-address selection still
+  binds, a bare name is still rejected loudly, and no other platform's
+  command, stream behavior, or public API changes. Only the contract and the
+  test expectation move (§req:windows-roundtrip-success-criteria — Windows
+  runtime unchanged; §req:windows-roundtrip-constraints — no new public API,
+  no behavior change; §spec:public-api-stability).
+- The round-trip shall be verified by automated tests that pass on a real
+  Windows host and whose pass/fail does **not** depend on which interface
+  names or addresses a particular runner reports. The expectation branches on
+  the platform's binding ability (name-binding vs. address-only), not on the
+  contents of the host's NIC list, so it is deterministic on any runner
+  (§req:windows-roundtrip-success-criteria — deterministic across runners;
+  §req:windows-roundtrip-quality-attributes — determinism, testability).
+- With the expectation corrected, the `core (windows-latest)` job shall pass,
+  so the cross-OS gate (§spec:ci) is green on Linux, Windows, and macOS
+  together and merges are no longer blocked by a test asserting behavior the
+  package intentionally does not have (§req:windows-roundtrip-success-criteria
+  — Windows core CI check passes; §req:windows-roundtrip-user-stories —
+  maintainer).
+- As a nice-to-have, the listing helper's documentation shall note that on
+  Windows a listed interface is passed back as its **source address**, not
+  its name, so the per-platform contract is discoverable at the point of use
+  (§req:windows-roundtrip-priorities — nice-to-have; §spec:interface-listing).
+
+**Why correct the expectation rather than make Windows accept names:** the
+package deliberately rejects a bare interface name on Windows
+(§spec:interface-platform-rejection) because the OS `ping` binds only by
+source address; silently approximating it would defeat the diagnostic the
+interface feature exists for (§spec:interface-selection). The test, not the
+package, was wrong — it asserted a guarantee §spec:interface-listing never
+made (the helper's normative contract is only that what it returns "can be
+fed back into `interface`," which the **address** satisfies everywhere, not
+that the **name** binds everywhere). A red required check that flags correct
+behavior trains maintainers to distrust the gate (§spec:ci — a required
+check must be reliable), so the honest fix is to align the expectation with
+the specified per-platform behavior.
+
+**Why the source address is the universal round-trip handle:** every
+platform's `ping` can bind a source address, while only some bind by name;
+choosing the address as the cross-platform handle is the one form that makes
+"pass one back into a `Ping`" true everywhere without per-platform branching
+at the call site (§req:windows-roundtrip-constraints — decided in discovery).
+
+**Why branch the test on binding ability, not on the host's NIC list:** the
+original failure was runner-dependent — it surfaced only because the Windows
+runner reported a named NIC. Keying the expectation off the platform's
+documented binding ability (does this `ping` bind by name?) rather than off
+whatever names/addresses `NetworkInterface.list()` returns makes the check
+reproducible on any runner and prevents the same contradiction from silently
+returning (§req:windows-roundtrip-quality-attributes — determinism,
+testability).
+
+**Alternative rejected — resolve a Windows interface name to its source
+address so names round-trip everywhere:** explicitly out of scope
+(§req:windows-roundtrip-constraints). It would add a per-platform
+name→address resolution surface — the kind of OS-specific text/lookup logic
+§spec:interface-listing deliberately avoided by building on `dart:io` — to
+paper over a difference the contract can simply state honestly. The cheaper,
+truthful design is to document that Windows round-trips by address.
+
+**Scope boundary:** this refines the interface contract and its tests only.
+The separate Windows IPv6 gap (#71) is not in scope, and no change is made to
+Linux/Android or macOS behavior. Traceability: surfaced by #85 (the CI work
+that ran the core suite on a Windows host), relating to the cross-OS matrix
+(#77, §spec:ci) and interface selection (#72,
+§spec:interface-selection / §spec:interface-platform-rejection /
+§spec:interface-listing).

--- a/dart_ping/CHANGELOG.md
+++ b/dart_ping/CHANGELOG.md
@@ -73,6 +73,13 @@ NAT64/IPv6-only reachability (#52, §spec:nat64-option):
   never raises an error. Passing `nat64Synthesis: false` restores raw
   pass-through (the family-pinned resolve, no synthesis).
 
+Interface round-trip clarification (#85, §spec:windows-roundtrip-contract):
+
+- Documentation only: clarify that an interface listed by
+  `listNetworkInterfaces()` round-trips into `Ping(host, interface: ...)`
+  by source address on Windows — a bare interface name is rejected there —
+  while the address form round-trips on every platform. No behavior change.
+
 ## 9.2.0
 
 - Add an optional `interface` selection to the `Ping` factory and the platform constructors (#72). Pass either a network interface name (e.g. `eth0`) or a local source IP address (e.g. `192.168.1.5`) to bind the ping to a specific interface or source address.

--- a/dart_ping/README.md
+++ b/dart_ping/README.md
@@ -62,6 +62,8 @@ await for (final event in ping.stream) {
 }
 ```
 
+On Windows you must pass back a source address (e.g. `interfaces.first.addresses.first.address`), not the name, because Windows `ping` binds only by source address; a bare interface name is rejected there. A source address round-trips on every platform.
+
 ### Non-English Language Support
 
 To support OS languages other than English, you can override the parser (Portuguese shown here):

--- a/dart_ping/lib/src/interface_listing.dart
+++ b/dart_ping/lib/src/interface_listing.dart
@@ -20,6 +20,13 @@ NetworkInterfaceLister networkInterfaceLister = NetworkInterface.list;
 /// or one of its `addresses` (`InternetAddress.address`, e.g.
 /// `192.168.1.5`) as the selection.
 ///
+/// On Windows the OS `ping` binds only by source address, so a bare
+/// interface `name` is rejected with a catchable [UnimplementedError];
+/// on Windows pass back one of the interface's `addresses`
+/// (`InternetAddress.address`), not its name. The address form
+/// round-trips on every platform; the name form only where the OS binds
+/// by name (Linux/Android, macOS).
+///
 /// Built on `dart:io`'s [NetworkInterface.list] — no `ifconfig`/`ip`/
 /// `ipconfig` text parsing. The [includeLoopback], [includeLinkLocal] and
 /// [type] arguments are forwarded unchanged.

--- a/dart_ping/test/interface_listing_test.dart
+++ b/dart_ping/test/interface_listing_test.dart
@@ -28,17 +28,12 @@ void main() {
         // name. Windows `ping` binds only by source address, so PingWindows
         // rejects a bare interface name synchronously in its constructor
         // (UnimplementedError) — there the name round-trips by address instead.
-        if (Platform.isWindows) {
-          expect(
-            () => Ping('127.0.0.1', interface: iface.name, count: 1),
-            throwsA(isA<UnimplementedError>()),
-          );
-        } else {
-          expect(
-            () => Ping('127.0.0.1', interface: iface.name, count: 1),
-            returnsNormally,
-          );
-        }
+        expect(
+          () => Ping('127.0.0.1', interface: iface.name, count: 1),
+          Platform.isWindows
+              ? throwsA(isA<UnimplementedError>())
+              : returnsNormally,
+        );
 
         // And so does a returned address string, when one is present.
         if (iface.addresses.isNotEmpty) {

--- a/dart_ping/test/interface_listing_test.dart
+++ b/dart_ping/test/interface_listing_test.dart
@@ -23,11 +23,22 @@ void main() {
         expect(iface.name, isNotEmpty);
         expect(iface.addresses, isA<List<InternetAddress>>());
 
-        // The loop closes: a returned name feeds back into a Ping selection.
-        expect(
-          () => Ping('127.0.0.1', interface: iface.name, count: 1),
-          returnsNormally,
-        );
+        // The loop closes per the platform's binding ability: a returned name
+        // only feeds back into a Ping selection where the OS `ping` binds by
+        // name. Windows `ping` binds only by source address, so PingWindows
+        // rejects a bare interface name synchronously in its constructor
+        // (UnimplementedError) — there the name round-trips by address instead.
+        if (Platform.isWindows) {
+          expect(
+            () => Ping('127.0.0.1', interface: iface.name, count: 1),
+            throwsA(isA<UnimplementedError>()),
+          );
+        } else {
+          expect(
+            () => Ping('127.0.0.1', interface: iface.name, count: 1),
+            returnsNormally,
+          );
+        }
 
         // And so does a returned address string, when one is present.
         if (iface.addresses.isNotEmpty) {


### PR DESCRIPTION
## What this builds

Extends the CI gate to the gitflow integration branch. Previously CI (`§spec:ci`) triggered only on PRs to `main`, so feature branches could land on `develop` unchecked and breakage accumulated until the late, batched `develop`→`main` release PR. This moves the gate earlier.

**Code change** — `.github/workflows/ci.yml`: add `develop` to `on.pull_request.branches` (`[main]` → `[main, develop]`) plus a header-comment update. One workflow definition, two branch targets, so parity with `main` is **structural — not a maintained copy** (the gates cannot drift; one place to change a job). `workflow_dispatch` and the `main` trigger/jobs are untouched.

**Branch protection** — `develop` is now protected identically to `main` (configured in repo settings, outside the workflow file, but part of this section's done state): same required checks (`core (ubuntu/windows/macos-latest)`, `ios-dart (ubuntu)`, `ios-swift (macos)`), force-pushes and deletions disabled, `enforce_admins: true`. `main`'s protection is unchanged.

## Spec sections now complete

- **`§spec:ci-develop`** — *CI gates pull requests to `develop`* → status flipped to **implemented**. Backed by `§req:ci-develop-*` (added in this branch).

## Reviewer integration test path

1. Open any PR targeting `develop` → confirm the full job set (core ×3 OS, ios-dart, ios-swift, coverage) starts automatically, with no manual action.
2. Confirm the same set runs on a PR to `main` exactly as before (unchanged).
3. In repo settings, confirm `develop`'s branch protection mirrors `main`: required checks listed above, no direct pushes, PR-required.
4. Confirm `workflow_dispatch` (manual run from the Actions tab) still works.
5. Live ICMP round-trips remain excluded everywhere (`dart test -x live`) — determinism is inherited by construction.

## Review status

An automated code review was already completed in kandev at the Review gate (no findings; CI green: core 196 pass, ios-dart 42 pass, analyze clean on both packages — the macOS-only `ios-swift` job is gated on CI's macOS runner). See this task's plan artifact, "Code review — ci-develop (gate PRs to develop)".

> Note: this branch is stacked on prior in-flight planning work (#52/#63/#69/#70/#72) not yet on `develop`, so the diff below spans more than the `ci.yml` change until those land.
