### PR TITLE
test: honest per-platform interface-listing round-trip contract (#85)

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,6 +1,6 @@
 # Requirements
 
-This document tracks eight areas of work:
+This document tracks nine areas of work:
 
 1. **iOS SPM migration (#73)** — *shipped in `dart_ping_ios` 5.0.0.*
    Replace the `flutter_icmp_ping` dependency with a native Swift ICMP
@@ -53,6 +53,17 @@ This document tracks eight areas of work:
    behind an explicit option that is enabled by default — extending the
    #69 scope boundary, which made the error honest but declined to make
    the ping work. Captured in the `§req:nat64-*` sections at the end.
+9. **Windows interface-listing round-trip contract (#85)** — the
+   interface-selection helper (#72) promised a listed interface could be
+   "passed back into a `Ping`," and a test read that as *every interface
+   name* round-tripping on *every* platform. That is false on Windows by
+   the package's own design: Windows `ping` binds only by source address
+   and a bare interface name is rejected. Once CI ran the core suite on a
+   real Windows host, the contradiction turned the Windows check red. Make
+   the round-trip contract honest per platform — the source **address**
+   round-trips everywhere, the **name** only where the OS binds by name —
+   without changing any platform's runtime behavior. Captured in the
+   `§req:windows-roundtrip-*` sections at the end.
 
 ---
 
@@ -1390,3 +1401,138 @@ mechanism is decided:
   Confirming that synthesis does not change the validated family or
   disturb the literal-vs-family `ArgumentError`
   (`§spec:address-family-mismatch-validation`).
+
+---
+
+# Windows interface-listing round-trip contract (#85)
+
+A clarification, not a new feature. The interface-selection work (#72,
+`§req:interface-*`) shipped a nice-to-have helper that lists the host's
+network interfaces so a developer can "pass one back into a `Ping`." An
+automated test read that promise as *every interface name round-trips
+into a `Ping` on every platform* — an assumption the package itself
+contradicts on Windows. The contradiction stayed hidden until the
+cross-OS CI matrix ran the core suite on a real Windows host, where it
+turned the Windows check red. This area makes the round-trip contract
+honest per platform.
+
+## Windows round-trip — problem statement §req:windows-roundtrip-problem-statement
+
+The affected party here is the **maintainer** (and any contributor whose
+PR is blocked by a red gate), and secondarily the **cross-platform
+developer** who relies on the interface-listing helper's promise.
+
+The interface-selection feature (#72) established two facts that are both
+correct and both already documented in `§req:interface-success-criteria`:
+
+- The listing helper returns the host's interfaces, "enough to identify
+  and pass one back into a `Ping`."
+- On Windows, the OS `ping` binds **only by source address** (`-S
+  <address>`), never by interface name, so passing a **bare interface
+  name** on Windows produces a clear, catchable error rather than silently
+  pinging the default route.
+
+A test encoded a *stronger* reading of the first fact than the second
+allows: that every listed interface's **name** can be fed back into
+`Ping(interface: name)` and construct without throwing, on **every**
+platform. That holds on Linux/Android and macOS, whose `ping` binds by
+name. It is **false on Windows** — by the package's own deliberate
+design, a bare name is rejected.
+
+The contradiction was invisible while CI gated only PRs to `main` on the
+existing matrix; it surfaced once the core suite ran on an actual Windows
+runner (the cross-OS matrix from #77, extended to PRs targeting `develop`
+in #85). The Windows runner reports a named NIC (`"Ethernet 3"`); the
+round-trip test feeds that name back into a Windows `Ping`, which
+**correctly** throws `UnimplementedError` ("Windows ping binds only by
+source address, not by interface name…"), and the test fails with
+`195 tests passed, 1 failed`.
+
+The user-visible problem is therefore a **red Windows CI check that
+blocks merges**, caused not by wrong Windows behavior but by a test
+asserting a guarantee the package never offered on Windows. The defect is
+in the *contract/expectation*, not in Windows ping behavior. Left
+unaddressed it is both **frequent** (every PR re-runs the gate) and
+**expensive** (a red required check stops the merge queue and erodes
+trust in the matrix), while masking the fact that Windows is, in truth,
+behaving exactly as specified.
+
+## Windows round-trip — success criteria §req:windows-roundtrip-success-criteria
+
+Observable, verifiable outcomes:
+
+- **The Windows core CI check passes.** The `core (windows-latest)` job
+  goes green on a host that reports named NICs, so the cross-OS gate is
+  green on Linux, Windows, and macOS together. *(must-have)*
+- **The round-trip promise is honest per platform.** A listed interface's
+  **source address** round-trips into a `Ping` — constructs without
+  throwing — on **every** supported desktop platform. A listed interface's
+  **name** round-trips **only** where the OS binds by name (Linux/Android,
+  macOS); on Windows, passing a listed **name** is rejected with the
+  clear, catchable error already specified, and passing the listed
+  **address** works. *(must-have)*
+- **Windows runtime behavior is unchanged.** Source-address selection
+  still binds on Windows; a bare interface name is still rejected loudly
+  (never a silent default-route ping). No platform's runtime behavior
+  changes — only the contract and the test's expectation do. *(must-have —
+  consistency with `§req:interface-success-criteria`.)*
+- **The check is deterministic across runners.** The round-trip is
+  verified by automated tests that pass on a real Windows host and do
+  **not** depend on which interface names or addresses a particular runner
+  happens to report. *(must-have — the original failure was runner-NIC
+  dependent.)*
+
+## Windows round-trip — user stories §req:windows-roundtrip-user-stories
+
+- As a maintainer, I want the Windows CI check to pass so that merges
+  aren't blocked by a test asserting behavior the package intentionally
+  does not have.
+- As a cross-platform developer using the listing helper, I want "pass one
+  back into a `Ping`" to be true everywhere — I can rely on a listed
+  interface's **source address** round-tripping on any desktop platform,
+  and I understand the **name** works only where the OS binds by name.
+- As a Windows developer enumerating interfaces, I want a clear, working
+  path (select by the source address) and a clear error if I pass a name,
+  rather than a confusing CI failure or a silent wrong-interface ping.
+
+## Windows round-trip — quality attributes §req:windows-roundtrip-quality-attributes
+
+- **Cross-platform honesty:** the documented round-trip contract matches
+  actual per-platform behavior; there is no "green everywhere" claim that
+  is false on one OS (`§req:interface-quality-attributes` —
+  cross-platform predictability).
+- **Determinism:** the verifying test does not depend on host-specific NIC
+  names or addresses, so it is reproducible on any runner.
+- **Backward compatibility:** no change to the public API and no change to
+  runtime behavior on Linux/Android, macOS, or Windows — only the contract
+  wording and the test expectation change.
+- **Testability:** the corrected round-trip is exercised on a real Windows
+  host in CI, so the same contradiction cannot silently return.
+
+## Windows round-trip — constraints §req:windows-roundtrip-constraints
+
+- **Refinement, not new capability.** This refines
+  `§req:interface-success-criteria` ("Available interfaces can be listed"
+  and "Windows honors the source-address form"). Windows keeps **rejecting
+  bare names**; the fix corrects the contract and the test, it does not add
+  Windows name binding.
+- **No new public API, no behavior change** on any platform. Scope is the
+  listing↔selection round-trip contract and the tests that assert it.
+- **Decided in discovery:** the round-trippable handle is the source
+  **address** universally; the **name** only where the OS binds by name.
+  Making Windows resolve a name → source address (so names round-trip
+  everywhere) is **explicitly out of scope**.
+- **Traceability:** surfaced by issue **#85** (the CI work that ran the
+  core suite on a Windows host); relates to the cross-OS matrix (#77) and
+  interface selection (#72). The separate Windows IPv6 gap (#71) is **not**
+  in scope.
+
+## Windows round-trip — priorities §req:windows-roundtrip-priorities
+
+- **Must-have:** the Windows core CI check green; an honest per-platform
+  round-trip contract (address everywhere, name only where bound by name);
+  Windows name-rejection / address-acceptance unchanged; a deterministic
+  test independent of host NIC names and addresses.
+- **Nice-to-have:** a documentation note on the listing helper explaining
+  that on Windows you pass back a listed interface's **source address**,
+  not its name.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2093,7 +2093,7 @@ listing↔selection round-trip contract honest per platform and proves it on a
 real Windows host, with no change to any platform's runtime behavior.
 
 ## Per-platform round-trip honesty §spec:windows-roundtrip-contract
-*Status: not started*
+*Status: implemented (Batch #85-1) — the round-trip test `dart_ping/test/interface_listing_test.dart` ("each interface has the right shape and round-trips into Ping") now branches the listed-**name** expectation on the platform's binding ability (`Platform.isWindows`): a name round-trips (`returnsNormally`) on name-binding platforms (Linux/Android, macOS) and is expected to throw the catchable `UnimplementedError` on Windows (which `PingWindows` raises at construction), while a listed source **address** round-trips (`returnsNormally`) on every desktop platform. The expectation no longer depends on which names/addresses a runner reports, so it is deterministic on any host and the `core (windows-latest)` job goes green alongside Linux and macOS. The listing helper's dartdoc, the README "Selecting a network interface" section, and the CHANGELOG note that on Windows a listed interface is passed back as its source address, not its name. No runtime, command, stream, or public-API change on any platform. Covered by network-free `dart test` (the full core suite passes `-x live`, 196 tests).*
 
 The handle a developer carries from `listNetworkInterfaces()` back into a
 `Ping(interface: …)` round-trips per the platform's actual binding ability:

--- a/SPEC.md
+++ b/SPEC.md
@@ -2065,3 +2065,122 @@ resolver outcome in → synthesized-send or typed-error out) — while the
 end-to-end reachability is verified by hand on an affected device, mirroring
 the suite's established deterministic-seam principle (§spec:ci,
 §spec:ios-tests).
+
+---
+
+# Windows interface-listing round-trip contract
+
+Solution-space design for issue #85 (`§req:windows-roundtrip-*`). A
+clarification of the interface work (#72, `§spec:interface-selection` …
+`§spec:interface-listing`), not a new capability. The listing helper
+(§spec:interface-listing) promises that what it returns "feeds straight back
+into a `Ping`'s `interface` value." A round-trip test encoded a *stronger*
+reading of that promise than the package ever offered — that *every listed
+interface's name* constructs a `Ping` without throwing on *every* platform —
+which the package contradicts on Windows by design (§spec:interface-platform-rejection:
+a bare name is rejected because Windows `ping` binds only by source address).
+
+The contradiction was invisible while the round-trip ran only on hosts whose
+`NetworkInterface.list()` happened to report addresses, and while the gate
+ran the core suite only where the assumption held. Once the cross-OS matrix
+(§spec:ci) ran the core suite on a real Windows runner — which reports a
+named NIC (e.g. `"Ethernet 3"`) — the test fed that name into a Windows
+`Ping`, the constructor correctly threw `UnimplementedError`, and the
+Windows check went red (`195 passed, 1 failed`). The defect is in the test's
+*expectation*, not in Windows behavior: Windows was doing exactly what
+§spec:interface-platform-rejection specifies. This area makes the
+listing↔selection round-trip contract honest per platform and proves it on a
+real Windows host, with no change to any platform's runtime behavior.
+
+## Per-platform round-trip honesty §spec:windows-roundtrip-contract
+*Status: not started*
+
+The handle a developer carries from `listNetworkInterfaces()` back into a
+`Ping(interface: …)` round-trips per the platform's actual binding ability:
+a listed interface's **source address** constructs a `Ping` without throwing
+on every supported desktop platform; a listed interface's **name** does so
+only where the OS `ping` binds by name (Linux/Android, macOS). On Windows a
+listed **name** is rejected with the catchable error already specified, and a
+listed **address** is accepted. Nothing about Windows runtime behavior
+changes — only the contract's wording and the test that asserts it.
+
+- A listed interface's source **address** shall round-trip — feed back into
+  `Ping('…', interface: addr)` and construct without throwing — on **every**
+  supported desktop platform (Linux/Android, macOS, Windows), because every
+  platform's `ping` can bind a source address (§req:windows-roundtrip-success-criteria
+  — round-trip honest per platform; §spec:interface-selection).
+- A listed interface's **name** shall round-trip the same way **only** on the
+  platforms whose `ping` binds by name (Linux/Android, macOS). On **Windows**,
+  passing a listed name shall be rejected by the same explicit, catchable
+  `UnimplementedError` specified in §spec:interface-platform-rejection —
+  Windows `ping` binds only by source address — never a silent default-route
+  ping (§req:windows-roundtrip-success-criteria — round-trip honest per
+  platform; §req:windows-roundtrip-constraints — Windows keeps rejecting bare
+  names).
+- Windows runtime behavior shall be unchanged: source-address selection still
+  binds, a bare name is still rejected loudly, and no other platform's
+  command, stream behavior, or public API changes. Only the contract and the
+  test expectation move (§req:windows-roundtrip-success-criteria — Windows
+  runtime unchanged; §req:windows-roundtrip-constraints — no new public API,
+  no behavior change; §spec:public-api-stability).
+- The round-trip shall be verified by automated tests that pass on a real
+  Windows host and whose pass/fail does **not** depend on which interface
+  names or addresses a particular runner reports. The expectation branches on
+  the platform's binding ability (name-binding vs. address-only), not on the
+  contents of the host's NIC list, so it is deterministic on any runner
+  (§req:windows-roundtrip-success-criteria — deterministic across runners;
+  §req:windows-roundtrip-quality-attributes — determinism, testability).
+- With the expectation corrected, the `core (windows-latest)` job shall pass,
+  so the cross-OS gate (§spec:ci) is green on Linux, Windows, and macOS
+  together and merges are no longer blocked by a test asserting behavior the
+  package intentionally does not have (§req:windows-roundtrip-success-criteria
+  — Windows core CI check passes; §req:windows-roundtrip-user-stories —
+  maintainer).
+- As a nice-to-have, the listing helper's documentation shall note that on
+  Windows a listed interface is passed back as its **source address**, not
+  its name, so the per-platform contract is discoverable at the point of use
+  (§req:windows-roundtrip-priorities — nice-to-have; §spec:interface-listing).
+
+**Why correct the expectation rather than make Windows accept names:** the
+package deliberately rejects a bare interface name on Windows
+(§spec:interface-platform-rejection) because the OS `ping` binds only by
+source address; silently approximating it would defeat the diagnostic the
+interface feature exists for (§spec:interface-selection). The test, not the
+package, was wrong — it asserted a guarantee §spec:interface-listing never
+made (the helper's normative contract is only that what it returns "can be
+fed back into `interface`," which the **address** satisfies everywhere, not
+that the **name** binds everywhere). A red required check that flags correct
+behavior trains maintainers to distrust the gate (§spec:ci — a required
+check must be reliable), so the honest fix is to align the expectation with
+the specified per-platform behavior.
+
+**Why the source address is the universal round-trip handle:** every
+platform's `ping` can bind a source address, while only some bind by name;
+choosing the address as the cross-platform handle is the one form that makes
+"pass one back into a `Ping`" true everywhere without per-platform branching
+at the call site (§req:windows-roundtrip-constraints — decided in discovery).
+
+**Why branch the test on binding ability, not on the host's NIC list:** the
+original failure was runner-dependent — it surfaced only because the Windows
+runner reported a named NIC. Keying the expectation off the platform's
+documented binding ability (does this `ping` bind by name?) rather than off
+whatever names/addresses `NetworkInterface.list()` returns makes the check
+reproducible on any runner and prevents the same contradiction from silently
+returning (§req:windows-roundtrip-quality-attributes — determinism,
+testability).
+
+**Alternative rejected — resolve a Windows interface name to its source
+address so names round-trip everywhere:** explicitly out of scope
+(§req:windows-roundtrip-constraints). It would add a per-platform
+name→address resolution surface — the kind of OS-specific text/lookup logic
+§spec:interface-listing deliberately avoided by building on `dart:io` — to
+paper over a difference the contract can simply state honestly. The cheaper,
+truthful design is to document that Windows round-trips by address.
+
+**Scope boundary:** this refines the interface contract and its tests only.
+The separate Windows IPv6 gap (#71) is not in scope, and no change is made to
+Linux/Android or macOS behavior. Traceability: surfaced by #85 (the CI work
+that ran the core suite on a Windows host), relating to the cross-OS matrix
+(#77, §spec:ci) and interface selection (#72,
+§spec:interface-selection / §spec:interface-platform-rejection /
+§spec:interface-listing).

--- a/dart_ping/CHANGELOG.md
+++ b/dart_ping/CHANGELOG.md
@@ -73,6 +73,13 @@ NAT64/IPv6-only reachability (#52, §spec:nat64-option):
   never raises an error. Passing `nat64Synthesis: false` restores raw
   pass-through (the family-pinned resolve, no synthesis).
 
+Interface round-trip clarification (#85, §spec:windows-roundtrip-contract):
+
+- Documentation only: clarify that an interface listed by
+  `listNetworkInterfaces()` round-trips into `Ping(host, interface: ...)`
+  by source address on Windows — a bare interface name is rejected there —
+  while the address form round-trips on every platform. No behavior change.
+
 ## 9.2.0
 
 - Add an optional `interface` selection to the `Ping` factory and the platform constructors (#72). Pass either a network interface name (e.g. `eth0`) or a local source IP address (e.g. `192.168.1.5`) to bind the ping to a specific interface or source address.

--- a/dart_ping/README.md
+++ b/dart_ping/README.md
@@ -62,6 +62,8 @@ await for (final event in ping.stream) {
 }
 ```
 
+On Windows you must pass back a source address (e.g. `interfaces.first.addresses.first.address`), not the name, because Windows `ping` binds only by source address; a bare interface name is rejected there. A source address round-trips on every platform.
+
 ### Non-English Language Support
 
 To support OS languages other than English, you can override the parser (Portuguese shown here):

--- a/dart_ping/lib/src/interface_listing.dart
+++ b/dart_ping/lib/src/interface_listing.dart
@@ -20,6 +20,13 @@ NetworkInterfaceLister networkInterfaceLister = NetworkInterface.list;
 /// or one of its `addresses` (`InternetAddress.address`, e.g.
 /// `192.168.1.5`) as the selection.
 ///
+/// On Windows the OS `ping` binds only by source address, so a bare
+/// interface `name` is rejected with a catchable [UnimplementedError];
+/// on Windows pass back one of the interface's `addresses`
+/// (`InternetAddress.address`), not its name. The address form
+/// round-trips on every platform; the name form only where the OS binds
+/// by name (Linux/Android, macOS).
+///
 /// Built on `dart:io`'s [NetworkInterface.list] — no `ifconfig`/`ip`/
 /// `ipconfig` text parsing. The [includeLoopback], [includeLinkLocal] and
 /// [type] arguments are forwarded unchanged.

--- a/dart_ping/test/interface_listing_test.dart
+++ b/dart_ping/test/interface_listing_test.dart
@@ -28,17 +28,12 @@ void main() {
         // name. Windows `ping` binds only by source address, so PingWindows
         // rejects a bare interface name synchronously in its constructor
         // (UnimplementedError) — there the name round-trips by address instead.
-        if (Platform.isWindows) {
-          expect(
-            () => Ping('127.0.0.1', interface: iface.name, count: 1),
-            throwsA(isA<UnimplementedError>()),
-          );
-        } else {
-          expect(
-            () => Ping('127.0.0.1', interface: iface.name, count: 1),
-            returnsNormally,
-          );
-        }
+        expect(
+          () => Ping('127.0.0.1', interface: iface.name, count: 1),
+          Platform.isWindows
+              ? throwsA(isA<UnimplementedError>())
+              : returnsNormally,
+        );
 
         // And so does a returned address string, when one is present.
         if (iface.addresses.isNotEmpty) {

--- a/dart_ping/test/interface_listing_test.dart
+++ b/dart_ping/test/interface_listing_test.dart
@@ -23,11 +23,22 @@ void main() {
         expect(iface.name, isNotEmpty);
         expect(iface.addresses, isA<List<InternetAddress>>());
 
-        // The loop closes: a returned name feeds back into a Ping selection.
-        expect(
-          () => Ping('127.0.0.1', interface: iface.name, count: 1),
-          returnsNormally,
-        );
+        // The loop closes per the platform's binding ability: a returned name
+        // only feeds back into a Ping selection where the OS `ping` binds by
+        // name. Windows `ping` binds only by source address, so PingWindows
+        // rejects a bare interface name synchronously in its constructor
+        // (UnimplementedError) — there the name round-trips by address instead.
+        if (Platform.isWindows) {
+          expect(
+            () => Ping('127.0.0.1', interface: iface.name, count: 1),
+            throwsA(isA<UnimplementedError>()),
+          );
+        } else {
+          expect(
+            () => Ping('127.0.0.1', interface: iface.name, count: 1),
+            returnsNormally,
+          );
+        }
 
         // And so does a returned address string, when one is present.
         if (iface.addresses.isNotEmpty) {


### PR DESCRIPTION
## What this does

Makes the interface-listing → `Ping` **round-trip contract honest per platform** (issue #85). This is a **test-expectation + documentation correction only — no runtime or public-API change** on any platform.

The interface-listing helper (`listNetworkInterfaces`, #72) promises a listed interface "feeds back into a `Ping`'s `interface` value." A round-trip test encoded a stronger reading — that *every listed interface name* constructs a `Ping(interface: name)` without throwing on *every* platform. That is false on Windows by the package's own design: Windows `ping` binds only by source **address**, so `PingWindows` rejects a bare interface **name** with a catchable `UnimplementedError` (§spec:interface-platform-rejection). Once the cross-OS matrix (#77) ran the core suite on a real Windows runner that reports a named NIC (e.g. `"Ethernet 3"`), the test fed that name into a Windows `Ping`, the constructor correctly threw, and `core (windows-latest)` went red (195 passed, 1 failed). The defect was in the test's expectation, not Windows behavior.

### Changes
- **`dart_ping/test/interface_listing_test.dart`** — the name round-trip expectation now branches on the platform's **binding ability**, not on the host's NIC list: `Platform.isWindows ? throwsA(isA<UnimplementedError>()) : returnsNormally`. The source-**address** round-trip stays `returnsNormally` on every platform. Keying off `Platform.isWindows` makes the check deterministic on any runner, independent of which interfaces it reports.
- **`dart_ping/lib/src/interface_listing.dart`** — dartdoc note: on Windows, pass a listed interface back as its source **address**, not its name; the address form round-trips everywhere, the name form only where the OS binds by name (Linux/Android, macOS).
- **`dart_ping/README.md`, `dart_ping/CHANGELOG.md`** — same per-platform note for consumers.
- **`SPEC.md`, `REQUIREMENTS.md`** — `§spec:windows-roundtrip-contract` + `§req:windows-roundtrip-*` captured and marked implemented.

Windows runtime behavior is unchanged: source-address selection still binds; a bare name is still rejected loudly (never a silent default-route ping).

## §spec sections now complete
- **`§spec:windows-roundtrip-contract`** — per-platform round-trip honesty (address round-trips on every desktop platform; name only where the OS binds by name; Windows name rejected, address accepted). Backed by `§req:windows-roundtrip-problem-statement` / `-success-criteria` / `-constraints` / `-quality-attributes` / `-user-stories` / `-priorities`.

## Integration test path for the reviewer
1. `cd dart_ping && dart pub get`
2. `dart analyze --fatal-infos` → clean
3. `dart test -x live` → all pass (196 locally; the previously-red `core (windows-latest)` job now passes because the name expectation matches the synchronous `UnimplementedError` `PingWindows` throws at construction).
4. Spot-check the contract: a listed interface's **address** constructs `Ping('host', interface: addr)` without throwing on every platform; a bare **name** constructs fine on Linux/macOS but throws `UnimplementedError` on Windows.
5. Confirm the cross-OS CI matrix (`core` on ubuntu/windows/macos, `ios-dart`, `ios-swift`) is green across all three OSes.

Out of scope (per §req:windows-roundtrip-constraints): resolving a Windows interface name → source address so names round-trip everywhere; the Windows IPv6 gap (#71).

## Note on the title
Titled `test:` rather than `feat:` deliberately — this PR ships no feature and no behavior/API change (only a corrected test expectation + docs), so a `feat:` would mis-trigger a minor release on the semantic-release pipeline.

## Review
An automated multi-agent code review was already completed in kandev during the Review gate (compared against `develop`). It found **no actionable correctness/cleanup findings** in the #85 delta and confirmed CI green. See the kandev planning task's plan artifact: *"Code review — Windows interface-listing round-trip contract (#85)"*.
