### PR TITLE
Pre-10.0.0 release hygiene: packaging, formatting, docs

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,5 @@
+# Internal governance documents — kept in the repository for contributors but
+# not shipped to pub.dev, where they would dominate the published archive and
+# add no value for package consumers.
+SPEC.md
+REQUIREMENTS.md

--- a/README.md
+++ b/README.md
@@ -45,11 +45,16 @@ void main() async {
 }
 ```
 
-Instead of listening to a stream, you can perform a single ping and immediately return the result like so:
+Instead of listening to a stream, you can perform a single ping and immediately return the first event like so:
 
 ```dart
-final result = await Ping('google.com', count: 1).stream.first;
+final event = await Ping('google.com', count: 1).stream.first;
 ```
+
+`stream.first` yields whatever [PingEvent] arrives first — a `PingResponse` on
+success, but a `PingError` if that first probe times out or the host is
+unreachable — so branch on the type (or be ready for `first` to surface an
+error) rather than assuming a successful reply.
 
 To print the underlying ping command that will be used
 (useful for debugging):

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,9 +1,9 @@
-# Defines a default set of lint rules enforced for
-# projects at Google. For details and rationale,
-# see https://github.com/dart-lang/pedantic#enabled-lints.
+# Enables the `recommended` lint rule set from package:lints, the rules the
+# Dart team recommends for published packages.
+# See https://github.com/dart-lang/lints for the rule list and rationale.
 include: package:lints/recommended.yaml
 
-# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
+# For lint rules and documentation, see https://dart.dev/tools/linter-rules.
 # Uncomment to specify additional rules.
 # linter:
 #   rules:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,9 +30,12 @@ class MyHomePage extends StatefulWidget {
 
 class MyHomePageState extends State<MyHomePage> {
   final List<PingEvent> _events = [];
-  final TextEditingController _controller =
-      TextEditingController(text: 'google.com');
-  final TextEditingController _ttlController = TextEditingController(text: '64');
+  final TextEditingController _controller = TextEditingController(
+    text: 'google.com',
+  );
+  final TextEditingController _ttlController = TextEditingController(
+    text: '64',
+  );
   StreamSubscription<PingEvent>? _subscription;
 
   void _startPing() {
@@ -72,9 +75,7 @@ class MyHomePageState extends State<MyHomePage> {
         : _events.map((e) => e.toString()).join('\n');
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('DartPing Flutter Demo'),
-      ),
+      appBar: AppBar(title: const Text('DartPing Flutter Demo')),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[

--- a/hook/gating.dart
+++ b/hook/gating.dart
@@ -32,5 +32,4 @@ import 'package:code_assets/code_assets.dart';
 bool shouldBuildIosAsset({
   required bool buildCodeAssets,
   required OS? targetOS,
-}) =>
-    buildCodeAssets && targetOS == OS.iOS;
+}) => buildCodeAssets && targetOS == OS.iOS;

--- a/lib/dart_ping.dart
+++ b/lib/dart_ping.dart
@@ -8,7 +8,9 @@ export 'package:dart_ping/src/address_family.dart'
     show ipLiteralFamily, validateAddressFamily;
 export 'package:dart_ping/src/ping_interface.dart';
 export 'package:dart_ping/src/models/ping_parser.dart';
-export 'package:dart_ping/src/interface_listing.dart' show listNetworkInterfaces;
+export 'package:dart_ping/src/interface_listing.dart'
+    show listNetworkInterfaces;
+
 // Note: `dart:io` types (NetworkInterface, InternetAddress, ...) are NOT
 // re-exported. `listNetworkInterfaces()` returns `List<NetworkInterface>`;
 // consumers import `dart:io` directly to name those types, which avoids

--- a/lib/src/address_family.dart
+++ b/lib/src/address_family.dart
@@ -26,7 +26,7 @@ IpVersion? ipLiteralFamily(String host) {
 /// (§spec:address-family-mismatch-validation).
 ///
 /// Centralised here so every entry point — the [Ping] factory, the core
-/// platform classes (via `BasePing`), and the iOS `DartPingIOS` bridge — fails
+/// platform classes (via `BasePing`), and the iOS `IosPing` constructor — fails
 /// fast with the identical error, instead of the guard living only in the
 /// factory and being bypassed by direct construction.
 void validateAddressFamily(String host, IpVersion ipVersion) {

--- a/lib/src/interface_listing.dart
+++ b/lib/src/interface_listing.dart
@@ -1,11 +1,12 @@
 import 'dart:io';
 
 /// Signature of [NetworkInterface.list]; the seam tests override.
-typedef NetworkInterfaceLister = Future<List<NetworkInterface>> Function({
-  bool includeLoopback,
-  bool includeLinkLocal,
-  InternetAddressType type,
-});
+typedef NetworkInterfaceLister =
+    Future<List<NetworkInterface>> Function({
+      bool includeLoopback,
+      bool includeLinkLocal,
+      InternetAddressType type,
+    });
 
 /// Enumeration backend, defaulting to the real SDK call. Tests override
 /// this (via a `package:dart_ping/src/interface_listing.dart` import) to
@@ -37,9 +38,8 @@ Future<List<NetworkInterface>> listNetworkInterfaces({
   bool includeLoopback = false,
   bool includeLinkLocal = false,
   InternetAddressType type = InternetAddressType.any,
-}) =>
-    networkInterfaceLister(
-      includeLoopback: includeLoopback,
-      includeLinkLocal: includeLinkLocal,
-      type: type,
-    );
+}) => networkInterfaceLister(
+  includeLoopback: includeLoopback,
+  includeLinkLocal: includeLinkLocal,
+  type: type,
+);

--- a/lib/src/models/ping_parser.dart
+++ b/lib/src/models/ping_parser.dart
@@ -50,8 +50,9 @@ class PingParser {
     // Timeout
     match = timeoutRgx.firstMatch(data);
     if (match != null) {
-      var seq =
-          match.groupNames.contains('seq') ? match.namedGroup('seq') : null;
+      var seq = match.groupNames.contains('seq')
+          ? match.namedGroup('seq')
+          : null;
 
       return PingError(
         ErrorType.requestTimedOut,
@@ -62,8 +63,9 @@ class PingParser {
     // Successful response
     match = responseRgx.firstMatch(data);
     if (match != null) {
-      var seq =
-          match.groupNames.contains('seq') ? match.namedGroup('seq') : null;
+      var seq = match.groupNames.contains('seq')
+          ? match.namedGroup('seq')
+          : null;
       var ttl = match.namedGroup('ttl');
       var time = match.namedGroup('time');
 
@@ -73,9 +75,7 @@ class PingParser {
         ttl: ttl == null ? null : int.parse(ttl),
         time: time == null
             ? null
-            : Duration(
-                microseconds: ((double.parse(time)) * 1000).floor(),
-              ),
+            : Duration(microseconds: ((double.parse(time)) * 1000).floor()),
       );
     }
 
@@ -103,8 +103,9 @@ class PingParser {
     // TTL Exceeded
     match = timeToLiveRgx.firstMatch(data);
     if (match != null) {
-      var seq =
-          match.groupNames.contains('seq') ? match.namedGroup('seq') : null;
+      var seq = match.groupNames.contains('seq')
+          ? match.namedGroup('seq')
+          : null;
 
       return PingError(
         ErrorType.timeToLiveExceeded,

--- a/lib/src/ping/base_ping.dart
+++ b/lib/src/ping/base_ping.dart
@@ -170,9 +170,10 @@ abstract class BasePing {
   ///
   /// Each raw stream is decoded and line-split independently before merging, so
   /// interleaved stderr/stdout writes cannot corrupt or split a line.
-  Stream<PingEvent> get _parsedOutput =>
-      StreamGroup.merge([_lines(_process!.stderr), _lines(_process!.stdout)])
-          .transform<PingEvent>(parser.transformParser);
+  Stream<PingEvent> get _parsedOutput => StreamGroup.merge([
+    _lines(_process!.stderr),
+    _lines(_process!.stdout),
+  ]).transform<PingEvent>(parser.transformParser);
 
   Future<void> _onListen() async {
     _started = true;
@@ -234,11 +235,11 @@ abstract class BasePing {
       _process?.kill(ProcessSignal.sigint);
       final mappedError =
           (error is ProcessException && error.errorCode == 2) ||
-                  error.toString().contains('No such file')
-              ? Exception(
-                  'Could not find ping binary on this system. Please ensure it is installed',
-                )
-              : error;
+              error.toString().contains('No such file')
+          ? Exception(
+              'Could not find ping binary on this system. Please ensure it is installed',
+            )
+          : error;
       _controller.addError(mappedError, stackTrace);
       await _closeController();
     }
@@ -305,9 +306,11 @@ abstract class BasePing {
         // wall-clock comes only from the (absent) native summary line.
         final received = stats.sampleCount;
         final probeFailures = _errors
-            .where((e) =>
-                e.error == ErrorType.requestTimedOut ||
-                e.error == ErrorType.timeToLiveExceeded)
+            .where(
+              (e) =>
+                  e.error == ErrorType.requestTimedOut ||
+                  e.error == ErrorType.timeToLiveExceeded,
+            )
             .length;
         summary = PingSummary(
           transmitted: received + probeFailures,

--- a/lib/src/ping/ios/dart_ping_bindings.dart
+++ b/lib/src/ping/ios/dart_ping_bindings.dart
@@ -163,10 +163,8 @@ final class DartPingEvent extends Struct {
 /// (`dart_ping_event_callback`): `void (*)(void *context, const
 /// dart_ping_event *event)`. WS2 wraps a Dart handler of this shape in a
 /// `NativeCallable.listen` and passes its `nativeFunction` to [dartPingStart].
-typedef DartPingEventCallbackNative = Void Function(
-  Pointer<Void> context,
-  Pointer<DartPingEvent> event,
-);
+typedef DartPingEventCallbackNative =
+    Void Function(Pointer<Void> context, Pointer<DartPingEvent> event);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // C entry points, bound to the `package:dart_ping/dart_ping_ffi` code asset.

--- a/lib/src/ping/ios/ios_event_mapper.dart
+++ b/lib/src/ping/ios/ios_event_mapper.dart
@@ -122,9 +122,7 @@ PingEvent mapNativeEvent(NativePingEvent ev) {
         transmitted: ev.transmitted,
         received: ev.received,
         // timeMicros == 0 means the engine reported no session duration.
-        time: ev.timeMicros == 0
-            ? null
-            : Duration(microseconds: ev.timeMicros),
+        time: ev.timeMicros == 0 ? null : Duration(microseconds: ev.timeMicros),
         errors: ev.errors.map((k) => PingError(_errorTypeFor(k))).toList(),
       );
   }

--- a/lib/src/ping/ios/ios_ping.dart
+++ b/lib/src/ping/ios/ios_ping.dart
@@ -91,8 +91,7 @@ class IosPing implements Ping {
   set parser(PingParser parser) => throw UnimplementedError();
 
   @override
-  String get command =>
-      'Ping on iOS is provided by a native Swift ICMP engine';
+  String get command => 'Ping on iOS is provided by a native Swift ICMP engine';
 
   @override
   Stream<PingEvent> get stream {
@@ -121,12 +120,14 @@ class IosPing implements Ping {
     // isolate's event loop, which is what makes iOS ping work from any isolate
     // (#48). Keep a reference so it is not GC'd and so it can be closed at
     // teardown.
-    _callable =
-        NativeCallable<DartPingEventCallbackNative>.listener(_handleNativeEvent);
+    _callable = NativeCallable<DartPingEventCallbackNative>.listener(
+      _handleNativeEvent,
+    );
 
     final hostPtr = _host.toNativeUtf8();
-    final family =
-        _ipVersion == IpVersion.ipv6 ? DartPingFamily.v6 : DartPingFamily.v4;
+    final family = _ipVersion == IpVersion.ipv6
+        ? DartPingFamily.v6
+        : DartPingFamily.v4;
 
     try {
       _handle = dartPingStart(

--- a/lib/src/ping/linux_ping.dart
+++ b/lib/src/ping/linux_ping.dart
@@ -16,39 +16,38 @@ class PingLinux extends BasePing implements Ping {
     String? interface,
     bool nat64Synthesis = true,
   }) : super(
-          host,
-          count,
-          interval,
-          timeout,
-          ttl,
-          ipVersion,
-          parser ?? defaultParser,
-          encoding,
-          false,
-          interface,
-          nat64Synthesis,
-        );
+         host,
+         count,
+         interval,
+         timeout,
+         ttl,
+         ipVersion,
+         parser ?? defaultParser,
+         encoding,
+         false,
+         interface,
+         nat64Synthesis,
+       );
 
   static PingParser get defaultParser => PingParser(
-        responseRgx: RegExp(
-          r'bytes from (?:.*)(?<ip>\b(?:\d{1,3}\.){3}\d{1,3}\b)\)?: icmp_seq=(?<seq>\d+) ttl=(?<ttl>\d+) time=(?<time>(\d+).?(\d+))',
-        ),
-        summaryRgx: RegExp(
-          r'(?<tx>\d+) packets transmitted, (?<rx>\d+) received,.*time (?<time>\d+)ms',
-        ),
-        timeoutRgx: RegExp(r'no answer yet for icmp_seq=(?<seq>\d+)'),
-        timeToLiveRgx: RegExp(
-          r'From (?<ip>.*)(?:.*) icmp_seq=(?<seq>\d+) Time to live exceeded',
-        ),
-        unknownHostStr:
-            RegExp(r'unknown host|service not known|failure in name'),
-        noRouteStrs: [
-          RegExp(r'[Nn]etwork is unreachable'),
-          RegExp(r'[Dd]estination [Hh]ost [Uu]nreachable'),
-          RegExp(r'[Nn]o route to host'),
-          RegExp(r'[Aa]ddress family for hostname not supported'),
-        ],
-      );
+    responseRgx: RegExp(
+      r'bytes from (?:.*)(?<ip>\b(?:\d{1,3}\.){3}\d{1,3}\b)\)?: icmp_seq=(?<seq>\d+) ttl=(?<ttl>\d+) time=(?<time>(\d+).?(\d+))',
+    ),
+    summaryRgx: RegExp(
+      r'(?<tx>\d+) packets transmitted, (?<rx>\d+) received,.*time (?<time>\d+)ms',
+    ),
+    timeoutRgx: RegExp(r'no answer yet for icmp_seq=(?<seq>\d+)'),
+    timeToLiveRgx: RegExp(
+      r'From (?<ip>.*)(?:.*) icmp_seq=(?<seq>\d+) Time to live exceeded',
+    ),
+    unknownHostStr: RegExp(r'unknown host|service not known|failure in name'),
+    noRouteStrs: [
+      RegExp(r'[Nn]etwork is unreachable'),
+      RegExp(r'[Dd]estination [Hh]ost [Uu]nreachable'),
+      RegExp(r'[Nn]o route to host'),
+      RegExp(r'[Aa]ddress family for hostname not supported'),
+    ],
+  );
 
   @override
   Map<String, String> get locale => {'LC_ALL': 'C'};

--- a/lib/src/ping/mac_ping.dart
+++ b/lib/src/ping/mac_ping.dart
@@ -16,43 +16,41 @@ class PingMac extends BasePing implements Ping {
     String? interface,
     bool nat64Synthesis = true,
   }) : super(
-          host,
-          count,
-          interval,
-          timeout,
-          ttl,
-          ipVersion,
-          parser ?? defaultParser,
-          encoding,
-          false,
-          interface,
-          nat64Synthesis,
-        );
+         host,
+         count,
+         interval,
+         timeout,
+         ttl,
+         ipVersion,
+         parser ?? defaultParser,
+         encoding,
+         false,
+         interface,
+         nat64Synthesis,
+       );
 
   static PingParser get defaultParser => PingParser(
-        responseRgx: RegExp(
-          r'bytes from (?<ip>.*): icmp_seq=(?<seq>\d+) ttl=(?<ttl>\d+) time=(?<time>(\d+).?(\d+))',
-        ),
-        summaryRgx: RegExp(
-          r'(?<tx>\d+) packets transmitted, (?<rx>\d+) packets received',
-        ),
-        timeoutRgx: RegExp(r'Request timeout for icmp_seq (?<seq>\d+)'),
-        timeToLiveRgx: RegExp(r'from (?<ip>.*): Time to live exceeded'),
-        unknownHostStr: RegExp(r'Unknown host'),
-        noRouteStrs: [
-          RegExp(r'[Nn]o route to host'),
-          RegExp(r'[Nn]etwork is unreachable'),
-          // Family-unavailable failures, matching the Linux parser's coverage
-          // so cross-platform code can branch on noRoute consistently (#69).
-          RegExp(r'[Aa]ddress family .*not supported'),
-        ],
-        // "Host is down" (EHOSTDOWN) is a host-liveness condition, not a
-        // routing/address-family failure, so it is NOT a noRoute; it falls
-        // through to the catch-all unknown rather than being mislabelled.
-        errorStrs: [
-          RegExp(r'[Hh]ost is down'),
-        ],
-      );
+    responseRgx: RegExp(
+      r'bytes from (?<ip>.*): icmp_seq=(?<seq>\d+) ttl=(?<ttl>\d+) time=(?<time>(\d+).?(\d+))',
+    ),
+    summaryRgx: RegExp(
+      r'(?<tx>\d+) packets transmitted, (?<rx>\d+) packets received',
+    ),
+    timeoutRgx: RegExp(r'Request timeout for icmp_seq (?<seq>\d+)'),
+    timeToLiveRgx: RegExp(r'from (?<ip>.*): Time to live exceeded'),
+    unknownHostStr: RegExp(r'Unknown host'),
+    noRouteStrs: [
+      RegExp(r'[Nn]o route to host'),
+      RegExp(r'[Nn]etwork is unreachable'),
+      // Family-unavailable failures, matching the Linux parser's coverage
+      // so cross-platform code can branch on noRoute consistently (#69).
+      RegExp(r'[Aa]ddress family .*not supported'),
+    ],
+    // "Host is down" (EHOSTDOWN) is a host-liveness condition, not a
+    // routing/address-family failure, so it is NOT a noRoute; it falls
+    // through to the catch-all unknown rather than being mislabelled.
+    errorStrs: [RegExp(r'[Hh]ost is down')],
+  );
 
   @override
   Map<String, String> get locale => {'LC_ALL': 'C'};

--- a/lib/src/ping/windows_ping.dart
+++ b/lib/src/ping/windows_ping.dart
@@ -17,18 +17,18 @@ class PingWindows extends BasePing implements Ping {
     String? interface,
     bool nat64Synthesis = true,
   }) : super(
-          host,
-          count,
-          interval,
-          timeout,
-          ttl,
-          ipVersion,
-          parser ?? defaultParser,
-          encoding,
-          forceCodepage,
-          interface,
-          nat64Synthesis,
-        ) {
+         host,
+         count,
+         interval,
+         timeout,
+         ttl,
+         ipVersion,
+         parser ?? defaultParser,
+         encoding,
+         forceCodepage,
+         interface,
+         nat64Synthesis,
+       ) {
     // Windows `ping` binds ONLY by source address, never by interface name.
     // Reject a bare name once, up front at construction (consistent with the
     // iOS rejection), rather than throwing lazily from the `command`/`params`
@@ -42,29 +42,28 @@ class PingWindows extends BasePing implements Ping {
   }
 
   static PingParser get defaultParser => PingParser(
-        // `bytes=` and `TTL=` are optional: Windows IPv4 replies carry both
-        // ("Reply from 8.8.8.8: bytes=32 time=6ms TTL=37"), but IPv6 replies
-        // carry neither ("Reply from ::1: time<1ms"), so the IPv6 hop has no
-        // reported TTL (#71).
-        responseRgx: RegExp(
-          r'Reply from (?<ip>.*): (?:bytes=(?:\d+) )?time(?:=|<)(?<time>\d+)ms(?: TTL=(?<ttl>\d+))?',
-        ),
-        summaryRgx:
-            RegExp(r'Sent = (?<tx>\d+), Received = (?<rx>\d+), Lost = (?:\d+)'),
-        timeoutRgx: RegExp(r'Request timed out'),
-        timeToLiveRgx: RegExp(r'Reply from (?<ip>.*): TTL expired in transit'),
-        unknownHostStr: RegExp(r'could not find host'),
-        noRouteStrs: [
-          RegExp(r'Destination host unreachable'),
-          // Windows reports an unrouteable network as "Destination net
-          // unreachable"; map it to noRoute too so the family/route-failure
-          // signal is branchable on Windows, not just Linux/macOS (#69).
-          RegExp(r'Destination net unreachable'),
-        ],
-        errorStrs: [
-          RegExp(r'General failure'),
-        ],
-      );
+    // `bytes=` and `TTL=` are optional: Windows IPv4 replies carry both
+    // ("Reply from 8.8.8.8: bytes=32 time=6ms TTL=37"), but IPv6 replies
+    // carry neither ("Reply from ::1: time<1ms"), so the IPv6 hop has no
+    // reported TTL (#71).
+    responseRgx: RegExp(
+      r'Reply from (?<ip>.*): (?:bytes=(?:\d+) )?time(?:=|<)(?<time>\d+)ms(?: TTL=(?<ttl>\d+))?',
+    ),
+    summaryRgx: RegExp(
+      r'Sent = (?<tx>\d+), Received = (?<rx>\d+), Lost = (?:\d+)',
+    ),
+    timeoutRgx: RegExp(r'Request timed out'),
+    timeToLiveRgx: RegExp(r'Reply from (?<ip>.*): TTL expired in transit'),
+    unknownHostStr: RegExp(r'could not find host'),
+    noRouteStrs: [
+      RegExp(r'Destination host unreachable'),
+      // Windows reports an unrouteable network as "Destination net
+      // unreachable"; map it to noRoute too so the family/route-failure
+      // signal is branchable on Windows, not just Linux/macOS (#69).
+      RegExp(r'Destination net unreachable'),
+    ],
+    errorStrs: [RegExp(r'General failure')],
+  );
 
   @override
   Map<String, String> get locale => {'LANG': 'en_US'};
@@ -95,9 +94,9 @@ class PingWindows extends BasePing implements Ping {
 
   @override
   PingError? interpretExitCode(int exitCode) => PingError(
-        ErrorType.unknown,
-        message: 'Ping process exited with code: $exitCode',
-      );
+    ErrorType.unknown,
+    message: 'Ping process exited with code: $exitCode',
+  );
 
   @override
   Exception throwExit(int exitCode) =>

--- a/lib/src/ping_interface.dart
+++ b/lib/src/ping_interface.dart
@@ -33,6 +33,7 @@ abstract class Ping {
   factory Ping(
     /// Hostname, domain, or IP which you would like to ping
     String host, {
+
     /// How many times the host should be pinged before the process ends
     int? count,
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ topics:
   - network
   - networking
   - latency
+  - ios
 
 environment:
   sdk: ">=3.10.0 <4.0.0"

--- a/test/address_family_error_test.dart
+++ b/test/address_family_error_test.dart
@@ -18,14 +18,14 @@ void main() {
     });
 
     test('Linux network is unreachable', () {
-      final res =
-          PingLinux.defaultParser.parse('connect: Network is unreachable');
+      final res = PingLinux.defaultParser.parse(
+        'connect: Network is unreachable',
+      );
       expect((res as PingError).error, ErrorType.noRoute);
     });
 
     test('macOS no route to host', () {
-      final res =
-          PingMac.defaultParser.parse('ping: sendto: No route to host');
+      final res = PingMac.defaultParser.parse('ping: sendto: No route to host');
       expect((res as PingError).error, ErrorType.noRoute);
     });
 
@@ -60,20 +60,23 @@ void main() {
 
   group('Genuine name-resolution failures stay ErrorType.unknownHost: ', () {
     test('Linux unknown host', () {
-      final res =
-          PingLinux.defaultParser.parse('ping: unknown host example.invalid');
+      final res = PingLinux.defaultParser.parse(
+        'ping: unknown host example.invalid',
+      );
       expect((res as PingError).error, ErrorType.unknownHost);
     });
 
     test('macOS unknown host', () {
-      final res =
-          PingMac.defaultParser.parse('ping: cannot resolve foo: Unknown host');
+      final res = PingMac.defaultParser.parse(
+        'ping: cannot resolve foo: Unknown host',
+      );
       expect((res as PingError).error, ErrorType.unknownHost);
     });
 
     test('Windows could not find host', () {
-      final res = PingWindows.defaultParser
-          .parse('Ping request could not find host foo.');
+      final res = PingWindows.defaultParser.parse(
+        'Ping request could not find host foo.',
+      );
       expect((res as PingError).error, ErrorType.unknownHost);
     });
   });

--- a/test/address_family_validation_test.dart
+++ b/test/address_family_validation_test.dart
@@ -39,10 +39,7 @@ void main() {
       });
 
       test('IPv6 literal (::1) + ipv6', () {
-        expect(
-          () => Ping('::1', ipVersion: IpVersion.ipv6),
-          returnsNormally,
-        );
+        expect(() => Ping('::1', ipVersion: IpVersion.ipv6), returnsNormally);
       });
     });
 

--- a/test/build_hook_gating_test.dart
+++ b/test/build_hook_gating_test.dart
@@ -64,10 +64,7 @@ void main() {
 
     test('covers every known OS (no unhandled target silently builds)', () {
       for (final os in OS.values) {
-        final builds = shouldBuildIosAsset(
-          buildCodeAssets: true,
-          targetOS: os,
-        );
+        final builds = shouldBuildIosAsset(buildCodeAssets: true, targetOS: os);
         expect(builds, os == OS.iOS, reason: 'only iOS builds; $os must not');
       }
     });

--- a/test/concurrent_isolation_test.dart
+++ b/test/concurrent_isolation_test.dart
@@ -20,11 +20,9 @@ const _hardTimeout = Duration(seconds: 5);
 /// path. That maximizes the chance of exposing cross-contamination between the
 /// two concurrent runs.
 class FakeProcess implements Process {
-  FakeProcess({
-    List<String> stdoutLines = const [],
-    required int exit,
-  })  : _stdout = _interleaved(stdoutLines),
-        _exitCode = Future<int>.value(exit);
+  FakeProcess({List<String> stdoutLines = const [], required int exit})
+    : _stdout = _interleaved(stdoutLines),
+      _exitCode = Future<int>.value(exit);
 
   /// Emits each line on a separate async tick so the merged line stream's
   /// events from two concurrent processes are interleaved rather than delivered
@@ -67,11 +65,9 @@ class FakeProcess implements Process {
 /// [PingLinux] is instantiated directly (not through the [Ping] platform
 /// factory) so the test is deterministic on any host OS.
 class TestPing extends PingLinux {
-  TestPing(
-    String host, {
-    required FakeProcess process,
-  })  : _process = process,
-        super(host, null, 1000, 1000, 255, IpVersion.ipv4);
+  TestPing(String host, {required FakeProcess process})
+    : _process = process,
+      super(host, null, 1000, 1000, 255, IpVersion.ipv4);
 
   final FakeProcess _process;
 
@@ -165,29 +161,45 @@ void main() {
       // identifying fields by stripping `stats` to a bare response.
       final responses = data
           .whereType<PingResponse>()
-          .map((r) => PingResponse(seq: r.seq, ttl: r.ttl, time: r.time, ip: r.ip))
+          .map(
+            (r) => PingResponse(seq: r.seq, ttl: r.ttl, time: r.time, ip: r.ip),
+          )
           .toList();
       expect(
         responses,
         fixture.expectedResponses,
-        reason: '${fixture.host} responses (seq/ttl/time/ip) must match only '
+        reason:
+            '${fixture.host} responses (seq/ttl/time/ip) must match only '
             'its own canned input, not the sibling run',
       );
 
       final summaries = data.whereType<PingSummary>().toList();
-      expect(summaries, hasLength(1),
-          reason: '${fixture.host} must emit exactly one summary');
+      expect(
+        summaries,
+        hasLength(1),
+        reason: '${fixture.host} must emit exactly one summary',
+      );
       final summary = summaries.single;
-      expect(summary.transmitted, fixture.expectedTransmitted,
-          reason: '${fixture.host} transmitted count must be its own');
-      expect(summary.received, fixture.expectedReceived,
-          reason: '${fixture.host} received count must be its own');
-      expect(summary.time, fixture.expectedSummaryTime,
-          reason: '${fixture.host} summary time must be its own');
+      expect(
+        summary.transmitted,
+        fixture.expectedTransmitted,
+        reason: '${fixture.host} transmitted count must be its own',
+      );
+      expect(
+        summary.received,
+        fixture.expectedReceived,
+        reason: '${fixture.host} received count must be its own',
+      );
+      expect(
+        summary.time,
+        fixture.expectedSummaryTime,
+        reason: '${fixture.host} summary time must be its own',
+      );
       expect(
         summary.errors.map((e) => e.error).toList(),
         fixture.expectedErrors,
-        reason: '${fixture.host} error list must reflect only its own run; '
+        reason:
+            '${fixture.host} error list must reflect only its own run; '
             'no error may bleed from the sibling',
       );
     }
@@ -204,20 +216,21 @@ void main() {
 
       // Drain both streams CONCURRENTLY so their interleaved events pass through
       // the shared parse/accumulate path at the same time.
-      final results = await Future.wait(<Future<List<PingEvent>>>[
-        pingA.stream.toList(),
-        pingB.stream.toList(),
-      ]).timeout(
-        _hardTimeout,
-        onTimeout: () => fail('concurrent streams hung within $_hardTimeout'),
-      );
+      final results =
+          await Future.wait(<Future<List<PingEvent>>>[
+            pingA.stream.toList(),
+            pingB.stream.toList(),
+          ]).timeout(
+            _hardTimeout,
+            onTimeout: () =>
+                fail('concurrent streams hung within $_hardTimeout'),
+          );
 
       expectIsolated(results[0], hostA);
       expectIsolated(results[1], hostB);
     });
 
-    test('sequential runs return the same distinct, isolated results',
-        () async {
+    test('sequential runs return the same distinct, isolated results', () async {
       // Regression guard: pinging one host at a time must yield each host's own
       // results unchanged — proving the fix changes nothing for sequential use.
       final pingA = TestPing(

--- a/test/interface_listing_test.dart
+++ b/test/interface_listing_test.dart
@@ -13,38 +13,40 @@ void main() {
       expect(result, isA<List<NetworkInterface>>());
     });
 
-    test('each interface has the right shape and round-trips into Ping',
-        () async {
-      final interfaces = await listNetworkInterfaces(includeLoopback: true);
+    test(
+      'each interface has the right shape and round-trips into Ping',
+      () async {
+        final interfaces = await listNetworkInterfaces(includeLoopback: true);
 
-      // No-op-but-passing if the host reports zero interfaces.
-      for (final iface in interfaces) {
-        expect(iface.name, isA<String>());
-        expect(iface.name, isNotEmpty);
-        expect(iface.addresses, isA<List<InternetAddress>>());
+        // No-op-but-passing if the host reports zero interfaces.
+        for (final iface in interfaces) {
+          expect(iface.name, isA<String>());
+          expect(iface.name, isNotEmpty);
+          expect(iface.addresses, isA<List<InternetAddress>>());
 
-        // The loop closes per the platform's binding ability: a returned name
-        // only feeds back into a Ping selection where the OS `ping` binds by
-        // name. Windows `ping` binds only by source address, so PingWindows
-        // rejects a bare interface name synchronously in its constructor
-        // (UnimplementedError) — there the name round-trips by address instead.
-        expect(
-          () => Ping('127.0.0.1', interface: iface.name, count: 1),
-          Platform.isWindows
-              ? throwsA(isA<UnimplementedError>())
-              : returnsNormally,
-        );
-
-        // And so does a returned address string, when one is present.
-        if (iface.addresses.isNotEmpty) {
-          final addr = iface.addresses.first.address;
+          // The loop closes per the platform's binding ability: a returned name
+          // only feeds back into a Ping selection where the OS `ping` binds by
+          // name. Windows `ping` binds only by source address, so PingWindows
+          // rejects a bare interface name synchronously in its constructor
+          // (UnimplementedError) — there the name round-trips by address instead.
           expect(
-            () => Ping('127.0.0.1', interface: addr, count: 1),
-            returnsNormally,
+            () => Ping('127.0.0.1', interface: iface.name, count: 1),
+            Platform.isWindows
+                ? throwsA(isA<UnimplementedError>())
+                : returnsNormally,
           );
+
+          // And so does a returned address string, when one is present.
+          if (iface.addresses.isNotEmpty) {
+            final addr = iface.addresses.first.address;
+            expect(
+              () => Ping('127.0.0.1', interface: addr, count: 1),
+              returnsNormally,
+            );
+          }
         }
-      }
-    });
+      },
+    );
   });
 
   group('listNetworkInterfaces failure: ', () {
@@ -55,17 +57,14 @@ void main() {
 
     test('propagates the enumeration error instead of swallowing it', () {
       final boom = const SocketException('interface enumeration failed');
-      networkInterfaceLister = ({
-        bool includeLoopback = false,
-        bool includeLinkLocal = false,
-        InternetAddressType type = InternetAddressType.any,
-      }) =>
-          Future<List<NetworkInterface>>.error(boom);
+      networkInterfaceLister =
+          ({
+            bool includeLoopback = false,
+            bool includeLinkLocal = false,
+            InternetAddressType type = InternetAddressType.any,
+          }) => Future<List<NetworkInterface>>.error(boom);
 
-      expectLater(
-        listNetworkInterfaces(),
-        throwsA(same(boom)),
-      );
+      expectLater(listNetworkInterfaces(), throwsA(same(boom)));
     });
   });
 }

--- a/test/ios_event_mapper_test.dart
+++ b/test/ios_event_mapper_test.dart
@@ -22,13 +22,15 @@ void main() {
   // and never rounded to whole milliseconds (§spec:stats-precision).
   group('mapNativeEvent', () {
     test('maps a response event to a PingResponse (microsecond time)', () {
-      final event = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.response,
-        seq: 3,
-        ttl: 55,
-        timeMicros: 12000, // microseconds == 12 ms
-        ip: '1.2.3.4',
-      ));
+      final event = mapNativeEvent(
+        const NativePingEvent(
+          kind: NativeEventKind.response,
+          seq: 3,
+          ttl: 55,
+          timeMicros: 12000, // microseconds == 12 ms
+          ip: '1.2.3.4',
+        ),
+      );
 
       expect(event, isA<PingResponse>());
       final response = event as PingResponse;
@@ -43,22 +45,27 @@ void main() {
 
     test('preserves sub-millisecond round-trip resolution', () {
       // 1500 microseconds == 1.5 ms: must NOT collapse to a whole millisecond.
-      final response = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.response,
-        seq: 1,
-        timeMicros: 1500,
-        ip: '1.2.3.4',
-      )) as PingResponse;
+      final response =
+          mapNativeEvent(
+                const NativePingEvent(
+                  kind: NativeEventKind.response,
+                  seq: 1,
+                  timeMicros: 1500,
+                  ip: '1.2.3.4',
+                ),
+              )
+              as PingResponse;
 
       expect(response.time, const Duration(microseconds: 1500));
       expect(response.time!.inMilliseconds, 1); // truncates, but the µs survive
     });
 
     test('maps a response event missing ttl/ip without throwing', () {
-      final response = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.response,
-        seq: 1,
-      )) as PingResponse;
+      final response =
+          mapNativeEvent(
+                const NativePingEvent(kind: NativeEventKind.response, seq: 1),
+              )
+              as PingResponse;
 
       expect(response.seq, 1);
       expect(response.ttl, isNull);
@@ -68,11 +75,13 @@ void main() {
     });
 
     test('maps a requestTimedOut error to a single PingError carrying seq', () {
-      final event = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.error,
-        errorKind: NativeErrorKind.requestTimedOut,
-        seq: 4,
-      ));
+      final event = mapNativeEvent(
+        const NativePingEvent(
+          kind: NativeEventKind.error,
+          errorKind: NativeErrorKind.requestTimedOut,
+          seq: 4,
+        ),
+      );
 
       // The sealed model has no combined response+error: a timed-out probe is
       // ONE PingError that carries its own seq.
@@ -86,12 +95,16 @@ void main() {
     });
 
     test('maps a timeToLiveExceeded error carrying seq + hop ip', () {
-      final error = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.error,
-        errorKind: NativeErrorKind.timeToLiveExceeded,
-        seq: 7,
-        ip: '10.0.0.1',
-      )) as PingError;
+      final error =
+          mapNativeEvent(
+                const NativePingEvent(
+                  kind: NativeEventKind.error,
+                  errorKind: NativeErrorKind.timeToLiveExceeded,
+                  seq: 7,
+                  ip: '10.0.0.1',
+                ),
+              )
+              as PingError;
 
       expect(error.error, ErrorType.timeToLiveExceeded);
       expect(error.seq, 7);
@@ -99,11 +112,15 @@ void main() {
     });
 
     test('a TTL-exceeded error with ip but no seq keeps ip, null seq', () {
-      final error = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.error,
-        errorKind: NativeErrorKind.timeToLiveExceeded,
-        ip: '192.168.1.1',
-      )) as PingError;
+      final error =
+          mapNativeEvent(
+                const NativePingEvent(
+                  kind: NativeEventKind.error,
+                  errorKind: NativeErrorKind.timeToLiveExceeded,
+                  ip: '192.168.1.1',
+                ),
+              )
+              as PingError;
 
       expect(error.error, ErrorType.timeToLiveExceeded);
       expect(error.ip, '192.168.1.1');
@@ -111,10 +128,14 @@ void main() {
     });
 
     test('maps an unknownHost error with no probe context', () {
-      final error = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.error,
-        errorKind: NativeErrorKind.unknownHost,
-      )) as PingError;
+      final error =
+          mapNativeEvent(
+                const NativePingEvent(
+                  kind: NativeEventKind.error,
+                  errorKind: NativeErrorKind.unknownHost,
+                ),
+              )
+              as PingError;
 
       expect(error.error, ErrorType.unknownHost);
       expect(error.seq, isNull);
@@ -122,10 +143,14 @@ void main() {
     });
 
     test('maps a standalone noReply error', () {
-      final error = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.error,
-        errorKind: NativeErrorKind.noReply,
-      )) as PingError;
+      final error =
+          mapNativeEvent(
+                const NativePingEvent(
+                  kind: NativeEventKind.error,
+                  errorKind: NativeErrorKind.noReply,
+                ),
+              )
+              as PingError;
 
       expect(error.error, ErrorType.noReply);
       expect(error.seq, isNull);
@@ -135,31 +160,41 @@ void main() {
       // The native engine reports noRoute when resolution/send for the SELECTED
       // family is impossible. It must land as ErrorType.noRoute, distinct from
       // unknownHost.
-      final error = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.error,
-        errorKind: NativeErrorKind.noRoute,
-      )) as PingError;
+      final error =
+          mapNativeEvent(
+                const NativePingEvent(
+                  kind: NativeEventKind.error,
+                  errorKind: NativeErrorKind.noRoute,
+                ),
+              )
+              as PingError;
 
       expect(error.error, ErrorType.noRoute);
       expect(error.error, isNot(ErrorType.unknownHost));
     });
 
     test('maps an unknown error via the catch-all', () {
-      final error = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.error,
-        errorKind: NativeErrorKind.unknown,
-      )) as PingError;
+      final error =
+          mapNativeEvent(
+                const NativePingEvent(
+                  kind: NativeEventKind.error,
+                  errorKind: NativeErrorKind.unknown,
+                ),
+              )
+              as PingError;
 
       expect(error.error, ErrorType.unknown);
     });
 
     test('maps a summary event WITH a time (microseconds)', () {
-      final event = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.summary,
-        transmitted: 5,
-        received: 4,
-        timeMicros: 5000000, // microseconds == 5 s
-      ));
+      final event = mapNativeEvent(
+        const NativePingEvent(
+          kind: NativeEventKind.summary,
+          transmitted: 5,
+          received: 4,
+          timeMicros: 5000000, // microseconds == 5 s
+        ),
+      );
 
       expect(event, isA<PingSummary>());
       final summary = event as PingSummary;
@@ -170,12 +205,16 @@ void main() {
     });
 
     test('maps a summary event WITHOUT a time (timeMicros 0 -> null)', () {
-      final summary = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.summary,
-        transmitted: 2,
-        received: 0,
-        // timeMicros defaults to 0 -> null time.
-      )) as PingSummary;
+      final summary =
+          mapNativeEvent(
+                const NativePingEvent(
+                  kind: NativeEventKind.summary,
+                  transmitted: 2,
+                  received: 0,
+                  // timeMicros defaults to 0 -> null time.
+                ),
+              )
+              as PingSummary;
 
       expect(summary.transmitted, 2);
       expect(summary.received, 0);
@@ -184,40 +223,45 @@ void main() {
     });
 
     test('maps a summary carrying a mix of errors, in order', () {
-      final summary = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.summary,
-        transmitted: 5,
-        received: 0,
-        timeMicros: 5000000,
-        errors: [
-          NativeErrorKind.timeToLiveExceeded,
-          NativeErrorKind.requestTimedOut,
-          NativeErrorKind.unknownHost,
-          NativeErrorKind.noReply,
-          NativeErrorKind.unknown,
-        ],
-      )) as PingSummary;
+      final summary =
+          mapNativeEvent(
+                const NativePingEvent(
+                  kind: NativeEventKind.summary,
+                  transmitted: 5,
+                  received: 0,
+                  timeMicros: 5000000,
+                  errors: [
+                    NativeErrorKind.timeToLiveExceeded,
+                    NativeErrorKind.requestTimedOut,
+                    NativeErrorKind.unknownHost,
+                    NativeErrorKind.noReply,
+                    NativeErrorKind.unknown,
+                  ],
+                ),
+              )
+              as PingSummary;
 
-      expect(
-        summary.errors.map((e) => e.error).toList(),
-        const <ErrorType>[
-          ErrorType.timeToLiveExceeded,
-          ErrorType.requestTimedOut,
-          ErrorType.unknownHost,
-          ErrorType.noReply,
-          ErrorType.unknown,
-        ],
-      );
+      expect(summary.errors.map((e) => e.error).toList(), const <ErrorType>[
+        ErrorType.timeToLiveExceeded,
+        ErrorType.requestTimedOut,
+        ErrorType.unknownHost,
+        ErrorType.noReply,
+        ErrorType.unknown,
+      ]);
     });
 
     test('maps a summary with an explicitly empty errors list to []', () {
-      final summary = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.summary,
-        transmitted: 3,
-        received: 3,
-        timeMicros: 3000000,
-        errors: [],
-      )) as PingSummary;
+      final summary =
+          mapNativeEvent(
+                const NativePingEvent(
+                  kind: NativeEventKind.summary,
+                  transmitted: 3,
+                  received: 3,
+                  timeMicros: 3000000,
+                  errors: [],
+                ),
+              )
+              as PingSummary;
 
       expect(summary.errors, isEmpty);
     });
@@ -231,64 +275,84 @@ void main() {
   // tests pin that the Dart mapper turns that into the honest typed PingError —
   // NOT a phantom unknownHost — and that a genuine name miss stays unknownHost.
   group('NAT64 synthesis-failure fallback maps to the honest typed error', () {
-    test('a noRoute synthesis failure maps to ErrorType.noRoute, not a phantom',
-        () {
-      final event = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.error,
-        errorKind: NativeErrorKind.noRoute,
-      ));
+    test(
+      'a noRoute synthesis failure maps to ErrorType.noRoute, not a phantom',
+      () {
+        final event = mapNativeEvent(
+          const NativePingEvent(
+            kind: NativeEventKind.error,
+            errorKind: NativeErrorKind.noRoute,
+          ),
+        );
 
-      expect(event, isA<PingError>());
-      expect((event as PingError).error, ErrorType.noRoute);
-      expect(event.error, isNot(ErrorType.unknownHost)); // not a phantom
-    });
+        expect(event, isA<PingError>());
+        expect((event as PingError).error, ErrorType.noRoute);
+        expect(event.error, isNot(ErrorType.unknownHost)); // not a phantom
+      },
+    );
 
     test('a genuine unknownHost stays ErrorType.unknownHost', () {
-      final event = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.error,
-        errorKind: NativeErrorKind.unknownHost,
-      ));
+      final event = mapNativeEvent(
+        const NativePingEvent(
+          kind: NativeEventKind.error,
+          errorKind: NativeErrorKind.unknownHost,
+        ),
+      );
 
       expect((event as PingError).error, ErrorType.unknownHost);
     });
   });
 
-  group('NAT64 regression guards: synthesis must not disturb working paths', () {
-    test('a normal response still maps to an intact PingResponse + stats', () {
-      final mapper = NativeEventStatsMapper();
-      final response = mapper.map(const NativePingEvent(
-        kind: NativeEventKind.response,
-        seq: 2,
-        ttl: 64,
-        timeMicros: 12000, // microseconds == 12 ms
-        ip: '13.35.27.1',
-      )) as PingResponse;
+  group(
+    'NAT64 regression guards: synthesis must not disturb working paths',
+    () {
+      test(
+        'a normal response still maps to an intact PingResponse + stats',
+        () {
+          final mapper = NativeEventStatsMapper();
+          final response =
+              mapper.map(
+                    const NativePingEvent(
+                      kind: NativeEventKind.response,
+                      seq: 2,
+                      ttl: 64,
+                      timeMicros: 12000, // microseconds == 12 ms
+                      ip: '13.35.27.1',
+                    ),
+                  )
+                  as PingResponse;
 
-      expect(response.seq, 2);
-      expect(response.ttl, 64);
-      expect(response.time, const Duration(microseconds: 12000));
-      expect(response.ip, '13.35.27.1');
-      // The working live path still stamps the running snapshot.
-      expect(response.stats, isNotNull);
-      expect(response.stats!.sampleCount, 1);
-    });
+          expect(response.seq, 2);
+          expect(response.ttl, 64);
+          expect(response.time, const Duration(microseconds: 12000));
+          expect(response.ip, '13.35.27.1');
+          // The working live path still stamps the running snapshot.
+          expect(response.stats, isNotNull);
+          expect(response.stats!.sampleCount, 1);
+        },
+      );
 
-    test('the bare mapper still maps a normal response unchanged', () {
-      final response = mapNativeEvent(const NativePingEvent(
-        kind: NativeEventKind.response,
-        seq: 5,
-        ttl: 55,
-        timeMicros: 9000,
-        ip: '1.1.1.1',
-      )) as PingResponse;
+      test('the bare mapper still maps a normal response unchanged', () {
+        final response =
+            mapNativeEvent(
+                  const NativePingEvent(
+                    kind: NativeEventKind.response,
+                    seq: 5,
+                    ttl: 55,
+                    timeMicros: 9000,
+                    ip: '1.1.1.1',
+                  ),
+                )
+                as PingResponse;
 
-      expect(response.seq, 5);
-      expect(response.ttl, 55);
-      expect(response.time, const Duration(microseconds: 9000));
-      expect(response.ip, '1.1.1.1');
-      expect(response.stats, isNull); // bare mapper attaches no stats
-    });
-  });
+        expect(response.seq, 5);
+        expect(response.ttl, 55);
+        expect(response.time, const Duration(microseconds: 9000));
+        expect(response.ip, '1.1.1.1');
+        expect(response.stats, isNull); // bare mapper attaches no stats
+      });
+    },
+  );
 
   // --- NativeEventStatsMapper: the native-event -> event/stats seam ---
   //
@@ -300,12 +364,12 @@ void main() {
   // honestly absent figures.
   group('NativeEventStatsMapper (stats parity with core)', () {
     NativePingEvent response(int seq, int timeMicros) => NativePingEvent(
-          kind: NativeEventKind.response,
-          seq: seq,
-          ttl: 64,
-          timeMicros: timeMicros,
-          ip: '1.2.3.4',
-        );
+      kind: NativeEventKind.response,
+      seq: seq,
+      ttl: 64,
+      timeMicros: timeMicros,
+      ip: '1.2.3.4',
+    );
 
     test('each probe carries the running snapshot core would compute', () {
       // Sub-millisecond, irregular samples so avg/stddev/jitter are non-trivial.
@@ -314,13 +378,17 @@ void main() {
       final samplesSoFar = <Duration>[];
 
       for (var i = 0; i < rttsMicros.length; i++) {
-        final event = mapper.map(response(i + 1, rttsMicros[i])) as PingResponse;
+        final event =
+            mapper.map(response(i + 1, rttsMicros[i])) as PingResponse;
         samplesSoFar.add(Duration(microseconds: rttsMicros[i]));
 
         // The i-th event's snapshot equals the core computation over the first
         // i+1 samples — the live↔core parity guarantee (§spec:stats-live).
-        expect(event.stats, RoundTripStats.fromSamples(samplesSoFar),
-            reason: 'snapshot after sample ${i + 1} must match core');
+        expect(
+          event.stats,
+          RoundTripStats.fromSamples(samplesSoFar),
+          reason: 'snapshot after sample ${i + 1} must match core',
+        );
       }
 
       // The final running snapshot has a real (non-null) population stddev and
@@ -340,11 +408,15 @@ void main() {
 
       // A timeout does NOT contribute to the RTT figures: its snapshot reflects
       // only the two successful replies seen so far.
-      final timeout = mapper.map(const NativePingEvent(
-        kind: NativeEventKind.error,
-        errorKind: NativeErrorKind.requestTimedOut,
-        seq: 3,
-      )) as PingError;
+      final timeout =
+          mapper.map(
+                const NativePingEvent(
+                  kind: NativeEventKind.error,
+                  errorKind: NativeErrorKind.requestTimedOut,
+                  seq: 3,
+                ),
+              )
+              as PingError;
 
       expect(
         timeout.stats,
@@ -363,12 +435,16 @@ void main() {
         mapper.map(response(i + 1, rttsMicros[i]));
       }
 
-      final summary = mapper.map(const NativePingEvent(
-        kind: NativeEventKind.summary,
-        transmitted: 3,
-        received: 3,
-        timeMicros: 9000000,
-      )) as PingSummary;
+      final summary =
+          mapper.map(
+                const NativePingEvent(
+                  kind: NativeEventKind.summary,
+                  transmitted: 3,
+                  received: 3,
+                  timeMicros: 9000000,
+                ),
+              )
+              as PingSummary;
 
       final expected = RoundTripStats.fromSamples(
         rttsMicros.map((m) => Duration(microseconds: m)),
@@ -382,27 +458,35 @@ void main() {
     test('zero-reply run reports absent figures, 100% loss', () {
       final mapper = NativeEventStatsMapper();
       // Two probes, both errors, no replies.
-      mapper.map(const NativePingEvent(
-        kind: NativeEventKind.error,
-        errorKind: NativeErrorKind.requestTimedOut,
-        seq: 1,
-      ));
-      mapper.map(const NativePingEvent(
-        kind: NativeEventKind.error,
-        errorKind: NativeErrorKind.requestTimedOut,
-        seq: 2,
-      ));
+      mapper.map(
+        const NativePingEvent(
+          kind: NativeEventKind.error,
+          errorKind: NativeErrorKind.requestTimedOut,
+          seq: 1,
+        ),
+      );
+      mapper.map(
+        const NativePingEvent(
+          kind: NativeEventKind.error,
+          errorKind: NativeErrorKind.requestTimedOut,
+          seq: 2,
+        ),
+      );
 
-      final summary = mapper.map(const NativePingEvent(
-        kind: NativeEventKind.summary,
-        transmitted: 2,
-        received: 0,
-        // timeMicros 0 -> null time.
-        errors: [
-          NativeErrorKind.requestTimedOut,
-          NativeErrorKind.requestTimedOut,
-        ],
-      )) as PingSummary;
+      final summary =
+          mapper.map(
+                const NativePingEvent(
+                  kind: NativeEventKind.summary,
+                  transmitted: 2,
+                  received: 0,
+                  // timeMicros 0 -> null time.
+                  errors: [
+                    NativeErrorKind.requestTimedOut,
+                    NativeErrorKind.requestTimedOut,
+                  ],
+                ),
+              )
+              as PingSummary;
 
       // Honest absence: no fabricated zeros for the round-trip figures.
       expect(summary.stats!.sampleCount, 0);
@@ -420,8 +504,10 @@ void main() {
       final mapper = NativeEventStatsMapper();
       final only = mapper.map(response(1, 1234)) as PingResponse;
 
-      expect(only.stats,
-          RoundTripStats.fromSamples(const [Duration(microseconds: 1234)]));
+      expect(
+        only.stats,
+        RoundTripStats.fromSamples(const [Duration(microseconds: 1234)]),
+      );
       expect(only.stats!.stddev, Duration.zero);
       expect(only.stats!.jitter, isNull);
     });

--- a/test/ios_ping_test.dart
+++ b/test/ios_ping_test.dart
@@ -92,10 +92,9 @@ void main() {
       // All constructed independently; the command is identical and constant,
       // confirming there is no per-instance mutation of shared state.
       expect(pings.length, 5);
-      expect(
-        pings.map((p) => p.command).toSet(),
-        {'Ping on iOS is provided by a native Swift ICMP engine'},
-      );
+      expect(pings.map((p) => p.command).toSet(), {
+        'Ping on iOS is provided by a native Swift ICMP engine',
+      });
     });
   });
 }

--- a/test/live_stats_test.dart
+++ b/test/live_stats_test.dart
@@ -21,10 +21,10 @@ const _hardTimeout = Duration(seconds: 5);
 /// own copy of the harness).
 class FakeProcess implements Process {
   FakeProcess({List<String> stdoutLines = const [], required int exit})
-      : _stdout = Stream<List<int>>.fromIterable(
-          stdoutLines.map((l) => utf8.encode('$l\n')),
-        ),
-        _exitCode = Future<int>.value(exit);
+    : _stdout = Stream<List<int>>.fromIterable(
+        stdoutLines.map((l) => utf8.encode('$l\n')),
+      ),
+      _exitCode = Future<int>.value(exit);
 
   final Stream<List<int>> _stdout;
   final Future<int> _exitCode;
@@ -52,8 +52,8 @@ class FakeProcess implements Process {
 /// shared parse/accumulate engine runs deterministically on any host.
 class TestPing extends PingLinux {
   TestPing({required FakeProcess process})
-      : _process = process,
-        super('1.1.1.1', null, 1000, 1000, 255, IpVersion.ipv4);
+    : _process = process,
+      super('1.1.1.1', null, 1000, 1000, 255, IpVersion.ipv4);
 
   final FakeProcess _process;
 
@@ -95,47 +95,56 @@ void main() {
       final probes = events.where((e) => e is PingResponse || e is PingError);
       expect(probes, isNotEmpty);
       for (final probe in probes) {
-        expect(probe.stats, isNotNull,
-            reason: 'every probe event must carry a running snapshot');
+        expect(
+          probe.stats,
+          isNotNull,
+          reason: 'every probe event must carry a running snapshot',
+        );
       }
     });
   });
 
   group('Live running stats — snapshot tracks the summary computation '
       '(§spec:stats-live / §spec:stats-tests)', () {
-    test('the i-th response snapshot equals fromSamples([rtt_0..rtt_i])',
-        () async {
-      final ping = TestPing(
-        process: FakeProcess(
-          stdoutLines: const [
-            '64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=10.0 ms',
-            '64 bytes from 1.1.1.1: icmp_seq=2 ttl=57 time=20.0 ms',
-            '64 bytes from 1.1.1.1: icmp_seq=3 ttl=57 time=30.0 ms',
-            '3 packets transmitted, 3 received, 0% packet loss, time 2003ms',
-          ],
-          exit: 0,
-        ),
-      );
+    test(
+      'the i-th response snapshot equals fromSamples([rtt_0..rtt_i])',
+      () async {
+        final ping = TestPing(
+          process: FakeProcess(
+            stdoutLines: const [
+              '64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=10.0 ms',
+              '64 bytes from 1.1.1.1: icmp_seq=2 ttl=57 time=20.0 ms',
+              '64 bytes from 1.1.1.1: icmp_seq=3 ttl=57 time=30.0 ms',
+              '3 packets transmitted, 3 received, 0% packet loss, time 2003ms',
+            ],
+            exit: 0,
+          ),
+        );
 
-      final events = await ping.stream.toList().timeout(_hardTimeout);
-      final responses = events.whereType<PingResponse>().toList();
-      expect(responses, hasLength(3));
+        final events = await ping.stream.toList().timeout(_hardTimeout);
+        final responses = events.whereType<PingResponse>().toList();
+        expect(responses, hasLength(3));
 
-      const rtts = [
-        Duration(milliseconds: 10),
-        Duration(milliseconds: 20),
-        Duration(milliseconds: 30),
-      ];
+        const rtts = [
+          Duration(milliseconds: 10),
+          Duration(milliseconds: 20),
+          Duration(milliseconds: 30),
+        ];
 
-      for (var i = 0; i < responses.length; i++) {
-        final expected = RoundTripStats.fromSamples(rtts.sublist(0, i + 1));
-        expect(responses[i].stats, equals(expected),
-            reason: 'snapshot on response #$i must summarize the first '
-                '${i + 1} replies and use identical computation');
-        // The snapshot grows one sample at a time as replies arrive.
-        expect(responses[i].stats!.sampleCount, i + 1);
-      }
-    });
+        for (var i = 0; i < responses.length; i++) {
+          final expected = RoundTripStats.fromSamples(rtts.sublist(0, i + 1));
+          expect(
+            responses[i].stats,
+            equals(expected),
+            reason:
+                'snapshot on response #$i must summarize the first '
+                '${i + 1} replies and use identical computation',
+          );
+          // The snapshot grows one sample at a time as replies arrive.
+          expect(responses[i].stats!.sampleCount, i + 1);
+        }
+      },
+    );
 
     test("a timeout's snapshot equals the snapshot of the successful replies "
         'seen so far — errors do not contribute RTT', () async {
@@ -260,64 +269,70 @@ void main() {
 
   group('Live running stats — loss-so-far matches terminal loss '
       '(§spec:stats-live / §spec:stats-tests)', () {
-    test('derived running loss at the final probe equals summary.packetLoss',
-        () async {
-      // Canned native summary: 3 transmitted, 2 received -> 33% loss.
-      final ping = TestPing(
-        process: FakeProcess(
-          stdoutLines: const [
-            '64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=10.0 ms',
-            'no answer yet for icmp_seq=2',
-            '64 bytes from 1.1.1.1: icmp_seq=3 ttl=57 time=30.0 ms',
-            '3 packets transmitted, 2 received, 33% packet loss, time 2003ms',
-          ],
-          exit: 0,
-        ),
-      );
+    test(
+      'derived running loss at the final probe equals summary.packetLoss',
+      () async {
+        // Canned native summary: 3 transmitted, 2 received -> 33% loss.
+        final ping = TestPing(
+          process: FakeProcess(
+            stdoutLines: const [
+              '64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=10.0 ms',
+              'no answer yet for icmp_seq=2',
+              '64 bytes from 1.1.1.1: icmp_seq=3 ttl=57 time=30.0 ms',
+              '3 packets transmitted, 2 received, 33% packet loss, time 2003ms',
+            ],
+            exit: 0,
+          ),
+        );
 
-      final events = await ping.stream.toList().timeout(_hardTimeout);
-      final summary = events.whereType<PingSummary>().single;
+        final events = await ping.stream.toList().timeout(_hardTimeout);
+        final summary = events.whereType<PingSummary>().single;
 
-      // Transmitted-so-far = count of probe events; received-so-far =
-      // running sampleCount on the final probe.
-      final probes =
-          events.where((e) => e is PingResponse || e is PingError).toList();
-      final transmittedSoFar = probes.length;
-      final receivedSoFar = _lastProbeEvent(events).stats!.sampleCount;
+        // Transmitted-so-far = count of probe events; received-so-far =
+        // running sampleCount on the final probe.
+        final probes = events
+            .where((e) => e is PingResponse || e is PingError)
+            .toList();
+        final transmittedSoFar = probes.length;
+        final receivedSoFar = _lastProbeEvent(events).stats!.sampleCount;
 
-      expect(transmittedSoFar, 3);
-      expect(receivedSoFar, 2);
+        expect(transmittedSoFar, 3);
+        expect(receivedSoFar, 2);
 
-      final derivedLoss = _lossPct(transmittedSoFar, receivedSoFar);
-      expect(derivedLoss, summary.packetLoss);
-      expect(derivedLoss, closeTo(33.33, 0.01));
-    });
+        final derivedLoss = _lossPct(transmittedSoFar, receivedSoFar);
+        expect(derivedLoss, summary.packetLoss);
+        expect(derivedLoss, closeTo(33.33, 0.01));
+      },
+    );
 
-    test('zero-reply run: derived running loss is 100%, matching summary',
-        () async {
-      final ping = TestPing(
-        process: FakeProcess(
-          stdoutLines: const [
-            'no answer yet for icmp_seq=1',
-            'no answer yet for icmp_seq=2',
-            '2 packets transmitted, 0 received, 100% packet loss, time 1001ms',
-          ],
-          exit: 1,
-        ),
-      );
+    test(
+      'zero-reply run: derived running loss is 100%, matching summary',
+      () async {
+        final ping = TestPing(
+          process: FakeProcess(
+            stdoutLines: const [
+              'no answer yet for icmp_seq=1',
+              'no answer yet for icmp_seq=2',
+              '2 packets transmitted, 0 received, 100% packet loss, time 1001ms',
+            ],
+            exit: 1,
+          ),
+        );
 
-      final events = await ping.stream.toList().timeout(_hardTimeout);
-      final summary = events.whereType<PingSummary>().single;
+        final events = await ping.stream.toList().timeout(_hardTimeout);
+        final summary = events.whereType<PingSummary>().single;
 
-      final probes =
-          events.where((e) => e is PingResponse || e is PingError).toList();
-      final transmittedSoFar = probes.length;
-      final receivedSoFar = _lastProbeEvent(events).stats!.sampleCount;
+        final probes = events
+            .where((e) => e is PingResponse || e is PingError)
+            .toList();
+        final transmittedSoFar = probes.length;
+        final receivedSoFar = _lastProbeEvent(events).stats!.sampleCount;
 
-      expect(receivedSoFar, 0);
-      final derivedLoss = _lossPct(transmittedSoFar, receivedSoFar);
-      expect(derivedLoss, 100.0);
-      expect(derivedLoss, summary.packetLoss);
-    });
+        expect(receivedSoFar, 0);
+        final derivedLoss = _lossPct(transmittedSoFar, receivedSoFar);
+        expect(derivedLoss, 100.0);
+        expect(derivedLoss, summary.packetLoss);
+      },
+    );
   });
 }

--- a/test/model_test.dart
+++ b/test/model_test.dart
@@ -27,10 +27,9 @@ void main() {
     });
 
     test('copyWith overrides each field', () {
-      final updated = PingError(ErrorType.noReply).copyWith(
-        error: ErrorType.unknownHost,
-        message: 'changed',
-      );
+      final updated = PingError(
+        ErrorType.noReply,
+      ).copyWith(error: ErrorType.unknownHost, message: 'changed');
       expect(updated.error, ErrorType.unknownHost);
       expect(updated.message, 'changed');
     });
@@ -47,30 +46,31 @@ void main() {
     });
 
     test('toMap serializes the human-readable error message', () {
-      expect(
-        PingError(ErrorType.timeToLiveExceeded, message: 'm').toMap(),
-        {
-          'type': 'error',
-          'error': 'Time To Live Exceeded',
-          'message': 'm',
-          'seq': null,
-          'ip': null,
-          'stats': null,
-        },
-      );
+      expect(PingError(ErrorType.timeToLiveExceeded, message: 'm').toMap(), {
+        'type': 'error',
+        'error': 'Time To Live Exceeded',
+        'message': 'm',
+        'seq': null,
+        'ip': null,
+        'stats': null,
+      });
     });
 
     test('toString appends seq and ip when present', () {
       expect(
-        PingError(ErrorType.timeToLiveExceeded, seq: 3, ip: '1.2.3.4')
-            .toString(),
+        PingError(
+          ErrorType.timeToLiveExceeded,
+          seq: 3,
+          ip: '1.2.3.4',
+        ).toString(),
         'timeToLiveExceeded, seq:3, ip:1.2.3.4',
       );
     });
 
     test('copyWith overrides seq and ip', () {
-      final updated = PingError(ErrorType.requestTimedOut)
-          .copyWith(seq: 5, ip: '9.9.9.9');
+      final updated = PingError(
+        ErrorType.requestTimedOut,
+      ).copyWith(seq: 5, ip: '9.9.9.9');
       expect(updated.seq, 5);
       expect(updated.ip, '9.9.9.9');
     });
@@ -183,9 +183,10 @@ void main() {
     });
 
     test('copyWith carries stats over and overrides it', () {
-      final stats = RoundTripStats.fromSamples(
-        [const Duration(milliseconds: 1), const Duration(milliseconds: 3)],
-      );
+      final stats = RoundTripStats.fromSamples([
+        const Duration(milliseconds: 1),
+        const Duration(milliseconds: 3),
+      ]);
       final original = PingSummary(transmitted: 2, received: 2, stats: stats);
       expect(original.copyWith().stats, stats);
       final other = RoundTripStats.fromSamples([const Duration(seconds: 1)]);
@@ -193,7 +194,9 @@ void main() {
     });
 
     test('equality and toMap include stats', () {
-      final stats = RoundTripStats.fromSamples([const Duration(milliseconds: 5)]);
+      final stats = RoundTripStats.fromSamples([
+        const Duration(milliseconds: 5),
+      ]);
       final a = PingSummary(transmitted: 1, received: 1, stats: stats);
       final b = PingSummary(transmitted: 1, received: 1, stats: stats);
       final c = PingSummary(transmitted: 1, received: 1);
@@ -283,10 +286,7 @@ void main() {
     });
 
     test('fromMap throws on an unknown type', () {
-      expect(
-        () => PingEvent.fromMap({'type': 'bogus'}),
-        throwsArgumentError,
-      );
+      expect(() => PingEvent.fromMap({'type': 'bogus'}), throwsArgumentError);
     });
   });
 }

--- a/test/nat64_option_test.dart
+++ b/test/nat64_option_test.dart
@@ -21,29 +21,59 @@ void main() {
     });
 
     test('nat64Synthesis threads the supplied value (true / false)', () {
-      final enabled =
-          PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4, nat64Synthesis: true);
-      final disabled =
-          PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4, nat64Synthesis: false);
+      final enabled = PingLinux(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        nat64Synthesis: true,
+      );
+      final disabled = PingLinux(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        nat64Synthesis: false,
+      );
       expect(enabled.nat64Synthesis, isTrue);
       expect(disabled.nat64Synthesis, isFalse);
     });
 
-    test('the option is an inert NO-OP: params/command are byte-for-byte equal',
-        () {
-      // Backward-compat guard: whether the option is omitted (default),
-      // explicitly true, or explicitly false, the spawned command must be
-      // identical — proving the subprocess option never touches the raw path.
-      final baseline = PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4);
-      final enabled =
-          PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4, nat64Synthesis: true);
-      final disabled =
-          PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4, nat64Synthesis: false);
-      expect(enabled.params, baseline.params);
-      expect(enabled.command, baseline.command);
-      expect(disabled.params, baseline.params);
-      expect(disabled.command, baseline.command);
-    });
+    test(
+      'the option is an inert NO-OP: params/command are byte-for-byte equal',
+      () {
+        // Backward-compat guard: whether the option is omitted (default),
+        // explicitly true, or explicitly false, the spawned command must be
+        // identical — proving the subprocess option never touches the raw path.
+        final baseline = PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4);
+        final enabled = PingLinux(
+          'host',
+          3,
+          1,
+          2,
+          64,
+          IpVersion.ipv4,
+          nat64Synthesis: true,
+        );
+        final disabled = PingLinux(
+          'host',
+          3,
+          1,
+          2,
+          64,
+          IpVersion.ipv4,
+          nat64Synthesis: false,
+        );
+        expect(enabled.params, baseline.params);
+        expect(enabled.command, baseline.command);
+        expect(disabled.params, baseline.params);
+        expect(disabled.command, baseline.command);
+      },
+    );
   });
 
   group('PingMac', () {
@@ -53,26 +83,56 @@ void main() {
     });
 
     test('nat64Synthesis threads the supplied value (true / false)', () {
-      final enabled =
-          PingMac('host', 3, 1, 2, 64, IpVersion.ipv4, nat64Synthesis: true);
-      final disabled =
-          PingMac('host', 3, 1, 2, 64, IpVersion.ipv4, nat64Synthesis: false);
+      final enabled = PingMac(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        nat64Synthesis: true,
+      );
+      final disabled = PingMac(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        nat64Synthesis: false,
+      );
       expect(enabled.nat64Synthesis, isTrue);
       expect(disabled.nat64Synthesis, isFalse);
     });
 
-    test('the option is an inert NO-OP: params/command are byte-for-byte equal',
-        () {
-      final baseline = PingMac('host', 3, 1, 2, 64, IpVersion.ipv4);
-      final enabled =
-          PingMac('host', 3, 1, 2, 64, IpVersion.ipv4, nat64Synthesis: true);
-      final disabled =
-          PingMac('host', 3, 1, 2, 64, IpVersion.ipv4, nat64Synthesis: false);
-      expect(enabled.params, baseline.params);
-      expect(enabled.command, baseline.command);
-      expect(disabled.params, baseline.params);
-      expect(disabled.command, baseline.command);
-    });
+    test(
+      'the option is an inert NO-OP: params/command are byte-for-byte equal',
+      () {
+        final baseline = PingMac('host', 3, 1, 2, 64, IpVersion.ipv4);
+        final enabled = PingMac(
+          'host',
+          3,
+          1,
+          2,
+          64,
+          IpVersion.ipv4,
+          nat64Synthesis: true,
+        );
+        final disabled = PingMac(
+          'host',
+          3,
+          1,
+          2,
+          64,
+          IpVersion.ipv4,
+          nat64Synthesis: false,
+        );
+        expect(enabled.params, baseline.params);
+        expect(enabled.command, baseline.command);
+        expect(disabled.params, baseline.params);
+        expect(disabled.command, baseline.command);
+      },
+    );
   });
 
   group('PingWindows', () {
@@ -84,25 +144,55 @@ void main() {
     });
 
     test('nat64Synthesis threads the supplied value (true / false)', () {
-      final enabled = PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4,
-          nat64Synthesis: true);
-      final disabled = PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4,
-          nat64Synthesis: false);
+      final enabled = PingWindows(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        nat64Synthesis: true,
+      );
+      final disabled = PingWindows(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        nat64Synthesis: false,
+      );
       expect(enabled.nat64Synthesis, isTrue);
       expect(disabled.nat64Synthesis, isFalse);
     });
 
-    test('the option is an inert NO-OP: params/command are byte-for-byte equal',
-        () {
-      final baseline = PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4);
-      final enabled = PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4,
-          nat64Synthesis: true);
-      final disabled = PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4,
-          nat64Synthesis: false);
-      expect(enabled.params, baseline.params);
-      expect(enabled.command, baseline.command);
-      expect(disabled.params, baseline.params);
-      expect(disabled.command, baseline.command);
-    });
+    test(
+      'the option is an inert NO-OP: params/command are byte-for-byte equal',
+      () {
+        final baseline = PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4);
+        final enabled = PingWindows(
+          'host',
+          3,
+          1,
+          2,
+          64,
+          IpVersion.ipv4,
+          nat64Synthesis: true,
+        );
+        final disabled = PingWindows(
+          'host',
+          3,
+          1,
+          2,
+          64,
+          IpVersion.ipv4,
+          nat64Synthesis: false,
+        );
+        expect(enabled.params, baseline.params);
+        expect(enabled.command, baseline.command);
+        expect(disabled.params, baseline.params);
+        expect(disabled.command, baseline.command);
+      },
+    );
   });
 }

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -57,12 +57,14 @@ void main() {
       expect((res as PingError).error, ErrorType.noRoute);
     });
 
-    test('Host is down maps to unknown (host liveness, not a routing failure)',
-        () async {
-      final res = parser.parse('ping: sendto: Host is down');
-      expect(res, isA<PingError>());
-      expect((res as PingError).error, ErrorType.unknown);
-    });
+    test(
+      'Host is down maps to unknown (host liveness, not a routing failure)',
+      () async {
+        final res = parser.parse('ping: sendto: Host is down');
+        expect(res, isA<PingError>());
+        expect((res as PingError).error, ErrorType.unknown);
+      },
+    );
 
     test('Network is unreachable (macOS)', () async {
       final res = parser.parse('ping: sendto: Network is unreachable');
@@ -128,7 +130,8 @@ void main() {
 
     test('Destination host unreachable (Linux)', () async {
       final res = parser.parse(
-          'From 192.168.1.1 icmp_seq=1 Destination Host Unreachable');
+        'From 192.168.1.1 icmp_seq=1 Destination Host Unreachable',
+      );
       expect(res, isA<PingError>());
       expect((res as PingError).error, ErrorType.noRoute);
     });
@@ -204,8 +207,9 @@ void main() {
     });
 
     test('Host Unreachable', () async {
-      final res =
-          parser.parse('Reply from 10.20.61.15: Destination host unreachable.');
+      final res = parser.parse(
+        'Reply from 10.20.61.15: Destination host unreachable.',
+      );
       expect(res, isA<PingError>());
       expect((res as PingError).error, ErrorType.noRoute);
       expect(res.message ?? '', isNotEmpty);

--- a/test/parser_edge_test.dart
+++ b/test/parser_edge_test.dart
@@ -48,8 +48,7 @@ void main() {
     });
 
     test('an errorStrs match carries the raw line through as the message', () {
-      final res =
-          PingWindows.defaultParser.parse('General failure.');
+      final res = PingWindows.defaultParser.parse('General failure.');
       expect(res, isA<PingError>());
       expect((res as PingError).error, ErrorType.unknown);
       expect(res.message, 'General failure.');

--- a/test/ping_test.dart
+++ b/test/ping_test.dart
@@ -38,7 +38,10 @@ void main() {
       var ping = Ping('201.202.203.204', count: 2, ttl: 1);
       var data = await ping.stream.last;
       expect(data, isA<PingSummary>());
-      expect((data as PingSummary).errors.toString(), contains('requestTimedOut'));
+      expect(
+        (data as PingSummary).errors.toString(),
+        contains('requestTimedOut'),
+      );
     });
   });
 }

--- a/test/platform_test.dart
+++ b/test/platform_test.dart
@@ -15,12 +15,20 @@ void main() {
   group('PingLinux', () {
     final ping = PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4);
 
-    test('params force IPv4 with -4 and include the standard flags + count', () {
-      expect(
-        ping.params,
-        ['-4', '-O', '-n', '-W 2', '-i 1', '-t 64', '-c 3'],
-      );
-    });
+    test(
+      'params force IPv4 with -4 and include the standard flags + count',
+      () {
+        expect(ping.params, [
+          '-4',
+          '-O',
+          '-n',
+          '-W 2',
+          '-i 1',
+          '-t 64',
+          '-c 3',
+        ]);
+      },
+    );
 
     test('params force IPv6 with -6', () {
       final v6 = PingLinux('host', 3, 1, 2, 64, IpVersion.ipv6);
@@ -59,7 +67,15 @@ void main() {
     });
 
     test('interface name appends -I <name> as separate argv tokens', () {
-      final named = PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4, interface: 'eth0');
+      final named = PingLinux(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        interface: 'eth0',
+      );
       expect(named.params, containsAllInOrder(['-I', 'eth0']));
       // Regression guard: the flag and value must NOT be glued into one token,
       // which would reach ping (launched without a shell) as a single argument
@@ -69,15 +85,30 @@ void main() {
     });
 
     test('interface address appends -I <address> as separate argv tokens', () {
-      final addr =
-          PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4, interface: '192.168.1.5');
+      final addr = PingLinux(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        interface: '192.168.1.5',
+      );
       expect(addr.params, containsAllInOrder(['-I', '192.168.1.5']));
       expect(addr.params, isNot(contains('-I 192.168.1.5')));
       expect(addr.command, contains('-I 192.168.1.5'));
     });
 
     test('empty interface is a no-op (treated as no selection)', () {
-      final empty = PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4, interface: '');
+      final empty = PingLinux(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        interface: '',
+      );
       expect(empty.params, ['-4', '-O', '-n', '-W 2', '-i 1', '-t 64', '-c 3']);
       expect(empty.params, isNot(anyElement(startsWith('-I'))));
     });
@@ -86,7 +117,15 @@ void main() {
       // Backward-compat guard: the pre-feature params/command must be
       // identical whether `interface` is unset or explicitly null.
       const expected = ['-4', '-O', '-n', '-W 2', '-i 1', '-t 64', '-c 3'];
-      final nullIface = PingLinux('host', 3, 1, 2, 64, IpVersion.ipv4, interface: null);
+      final nullIface = PingLinux(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        interface: null,
+      );
       expect(ping.params, expected);
       expect(nullIface.params, expected);
       expect(nullIface.params, ping.params);
@@ -130,7 +169,15 @@ void main() {
     });
 
     test('interface name appends -b <name> (boundif) as separate tokens', () {
-      final named = PingMac('host', 3, 1, 2, 64, IpVersion.ipv4, interface: 'en0');
+      final named = PingMac(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        interface: 'en0',
+      );
       expect(named.params, containsAllInOrder(['-b', 'en0']));
       expect(named.params, isNot(contains('-b en0')));
       expect(named.command, contains('-b en0'));
@@ -138,23 +185,39 @@ void main() {
     });
 
     test('interface address appends -S <address> as separate tokens', () {
-      final addr =
-          PingMac('host', 3, 1, 2, 64, IpVersion.ipv4, interface: '192.168.1.5');
+      final addr = PingMac(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        interface: '192.168.1.5',
+      );
       expect(addr.params, containsAllInOrder(['-S', '192.168.1.5']));
       expect(addr.params, isNot(contains('-S 192.168.1.5')));
       expect(addr.command, contains('-S 192.168.1.5'));
       expect(addr.params, isNot(contains('-b')));
     });
 
-    test('zone-scoped IPv6 source address is classified as an address (-S)',
-        () {
-      // `InternetAddress.tryParse` rejects the `%zone` suffix, so the zone is
-      // stripped for classification; the full value is still passed to ping.
-      final zoned =
-          PingMac('host', 3, 1, 2, 64, IpVersion.ipv4, interface: 'fe80::1%en0');
-      expect(zoned.params, containsAllInOrder(['-S', 'fe80::1%en0']));
-      expect(zoned.params, isNot(contains('-b')));
-    });
+    test(
+      'zone-scoped IPv6 source address is classified as an address (-S)',
+      () {
+        // `InternetAddress.tryParse` rejects the `%zone` suffix, so the zone is
+        // stripped for classification; the full value is still passed to ping.
+        final zoned = PingMac(
+          'host',
+          3,
+          1,
+          2,
+          64,
+          IpVersion.ipv4,
+          interface: 'fe80::1%en0',
+        );
+        expect(zoned.params, containsAllInOrder(['-S', 'fe80::1%en0']));
+        expect(zoned.params, isNot(contains('-b')));
+      },
+    );
 
     test('empty interface is a no-op (treated as no selection)', () {
       final empty = PingMac('host', 3, 1, 2, 64, IpVersion.ipv4, interface: '');
@@ -166,7 +229,15 @@ void main() {
     test('omitting interface (or null) is byte-for-byte unchanged', () {
       // Backward-compat guard: pre-feature params/command unchanged.
       const expected = ['-n', '-W 2000', '-i 1', '-m 64', '-c 3'];
-      final nullIface = PingMac('host', 3, 1, 2, 64, IpVersion.ipv4, interface: null);
+      final nullIface = PingMac(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        interface: null,
+      );
       expect(ping.params, expected);
       expect(nullIface.params, expected);
       expect(nullIface.params, ping.params);
@@ -208,8 +279,15 @@ void main() {
     });
 
     test('interface address appends split -S <address> args', () {
-      final addr =
-          PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4, interface: '192.168.1.5');
+      final addr = PingWindows(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        interface: '192.168.1.5',
+      );
       expect(addr.params, containsAllInOrder(['-S', '192.168.1.5']));
       expect(addr.command, contains('-S 192.168.1.5'));
     });
@@ -220,7 +298,8 @@ void main() {
       // ping the default route. The rejection happens once at construction (not
       // lazily from `params`/`command`), so inspecting `command` never throws.
       expect(
-        () => PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4, interface: 'eth0'),
+        () =>
+            PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4, interface: 'eth0'),
         throwsA(
           isA<UnimplementedError>().having(
             (e) => e.toString(),
@@ -234,8 +313,15 @@ void main() {
     test('an accepted source-address selection lets command be inspected', () {
       // Regression guard for the fix that moved rejection to construction: the
       // pure inspection getters must never throw for a valid selection.
-      final addr =
-          PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4, interface: '192.168.1.5');
+      final addr = PingWindows(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        interface: '192.168.1.5',
+      );
       expect(() => addr.command, returnsNormally);
       expect(() => addr.params, returnsNormally);
     });
@@ -244,14 +330,29 @@ void main() {
       // A legitimate source address with an IPv6 zone id must not be mistaken
       // for a bare interface name and rejected.
       expect(
-        () =>
-            PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4, interface: 'fe80::1%eth0'),
+        () => PingWindows(
+          'host',
+          3,
+          1,
+          2,
+          64,
+          IpVersion.ipv4,
+          interface: 'fe80::1%eth0',
+        ),
         returnsNormally,
       );
     });
 
     test('empty interface is a no-op, not a rejected name', () {
-      final empty = PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4, interface: '');
+      final empty = PingWindows(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        interface: '',
+      );
       expect(empty.params, ['-w', '2000', '-i', '64', '-4', '-n', '3']);
       expect(empty.params, isNot(contains('-S')));
     });
@@ -259,8 +360,15 @@ void main() {
     test('omitting interface (or null) is byte-for-byte unchanged', () {
       // Backward-compat guard: pre-feature params/command unchanged.
       const expected = ['-w', '2000', '-i', '64', '-4', '-n', '3'];
-      final nullIface =
-          PingWindows('host', 3, 1, 2, 64, IpVersion.ipv4, interface: null);
+      final nullIface = PingWindows(
+        'host',
+        3,
+        1,
+        2,
+        64,
+        IpVersion.ipv4,
+        interface: null,
+      );
       expect(ping.params, expected);
       expect(nullIface.params, expected);
       expect(nullIface.params, ping.params);

--- a/test/round_trip_stats_test.dart
+++ b/test/round_trip_stats_test.dart
@@ -20,10 +20,7 @@ void main() {
       // Population stddev = sqrt(((10-20)^2 + 0 + (30-20)^2)/3) ms
       //                   = sqrt(200/3) ms ~= 8.16497 ms.
       final expectedStddevMicros = math.sqrt(200 / 3) * 1000;
-      expect(
-        stats.stddev!.inMicroseconds,
-        closeTo(expectedStddevMicros, 2),
-      );
+      expect(stats.stddev!.inMicroseconds, closeTo(expectedStddevMicros, 2));
 
       // Jitter = (|20-10| + |30-20|) / 2 = 10 ms.
       expect(stats.jitter, const Duration(milliseconds: 10));
@@ -49,8 +46,9 @@ void main() {
     });
 
     test('single sample', () {
-      final stats =
-          RoundTripStats.fromSamples(const [Duration(milliseconds: 42)]);
+      final stats = RoundTripStats.fromSamples(const [
+        Duration(milliseconds: 42),
+      ]);
 
       expect(stats.sampleCount, 1);
       expect(stats.min, const Duration(milliseconds: 42));
@@ -167,8 +165,11 @@ void main() {
       acc.add(const Duration(microseconds: 3000));
       final after = acc.snapshot();
 
-      expect(identical(before, after), isFalse,
-          reason: 'a new sample must invalidate the memoized snapshot');
+      expect(
+        identical(before, after),
+        isFalse,
+        reason: 'a new sample must invalidate the memoized snapshot',
+      );
       expect(after.sampleCount, 2);
       // The recomputed snapshot equals a fresh batch computation over the
       // same samples — memoization changes nothing observable.

--- a/test/serialization_test.dart
+++ b/test/serialization_test.dart
@@ -70,11 +70,7 @@ void main() {
         const Duration(milliseconds: 1),
         const Duration(milliseconds: 3),
       ]);
-      final summary = PingSummary(
-        transmitted: 2,
-        received: 2,
-        stats: stats,
-      );
+      final summary = PingSummary(transmitted: 2, received: 2, stats: stats);
       final deserialized = PingSummary.fromJson(summary.toJson());
       expect(deserialized, equals(summary));
       expect(deserialized.stats, equals(stats));

--- a/test/stats_event_test.dart
+++ b/test/stats_event_test.dart
@@ -15,10 +15,10 @@ const _hardTimeout = Duration(seconds: 5);
 /// In-memory [Process] stand-in that emits canned stdout lines then exits.
 class FakeProcess implements Process {
   FakeProcess({List<String> stdoutLines = const [], required int exit})
-      : _stdout = Stream<List<int>>.fromIterable(
-          stdoutLines.map((l) => utf8.encode('$l\n')),
-        ),
-        _exitCode = Future<int>.value(exit);
+    : _stdout = Stream<List<int>>.fromIterable(
+        stdoutLines.map((l) => utf8.encode('$l\n')),
+      ),
+      _exitCode = Future<int>.value(exit);
 
   final Stream<List<int>> _stdout;
   final Future<int> _exitCode;
@@ -46,8 +46,8 @@ class FakeProcess implements Process {
 /// shared parse/accumulate engine runs deterministically on any host.
 class TestPing extends PingLinux {
   TestPing({required FakeProcess process})
-      : _process = process,
-        super('1.1.1.1', null, 1000, 1000, 255, IpVersion.ipv4);
+    : _process = process,
+      super('1.1.1.1', null, 1000, 1000, 255, IpVersion.ipv4);
 
   final FakeProcess _process;
 
@@ -81,8 +81,10 @@ void main() {
       // The terminal summary is the final event.
       expect(events.last, isA<PingSummary>());
       // ...and only the last event is a summary.
-      expect(events.sublist(0, events.length - 1).whereType<PingSummary>(),
-          isEmpty);
+      expect(
+        events.sublist(0, events.length - 1).whereType<PingSummary>(),
+        isEmpty,
+      );
 
       final err = events.whereType<PingError>().single;
       expect(err.error, ErrorType.requestTimedOut);
@@ -137,32 +139,34 @@ void main() {
       expect(stats.jitter, isNotNull);
     });
 
-    test('BasePing builds summary stats from the per-probe reply times',
-        () async {
-      final ping = TestPing(
-        process: FakeProcess(
-          stdoutLines: const [
-            '64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=10.0 ms',
-            '64 bytes from 1.1.1.1: icmp_seq=2 ttl=57 time=20.0 ms',
-            '64 bytes from 1.1.1.1: icmp_seq=3 ttl=57 time=30.0 ms',
-            '3 packets transmitted, 3 received, 0% packet loss, time 2003ms',
-          ],
-          exit: 0,
-        ),
-      );
+    test(
+      'BasePing builds summary stats from the per-probe reply times',
+      () async {
+        final ping = TestPing(
+          process: FakeProcess(
+            stdoutLines: const [
+              '64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=10.0 ms',
+              '64 bytes from 1.1.1.1: icmp_seq=2 ttl=57 time=20.0 ms',
+              '64 bytes from 1.1.1.1: icmp_seq=3 ttl=57 time=30.0 ms',
+              '3 packets transmitted, 3 received, 0% packet loss, time 2003ms',
+            ],
+            exit: 0,
+          ),
+        );
 
-      final events = await ping.stream.toList().timeout(_hardTimeout);
-      final summary = events.whereType<PingSummary>().single;
+        final events = await ping.stream.toList().timeout(_hardTimeout);
+        final summary = events.whereType<PingSummary>().single;
 
-      final expected = RoundTripStats.fromSamples(const [
-        Duration(milliseconds: 10),
-        Duration(milliseconds: 20),
-        Duration(milliseconds: 30),
-      ]);
-      expect(summary.stats, equals(expected));
-      expect(summary.stats!.stddev, isNotNull);
-      expect(summary.packetLoss, 0.0);
-    });
+        final expected = RoundTripStats.fromSamples(const [
+          Duration(milliseconds: 10),
+          Duration(milliseconds: 20),
+          Duration(milliseconds: 30),
+        ]);
+        expect(summary.stats, equals(expected));
+        expect(summary.stats!.stddev, isNotNull);
+        expect(summary.packetLoss, 0.0);
+      },
+    );
 
     test('a run with no replies yields an empty (absent-figures) stats '
         'snapshot', () async {
@@ -184,8 +188,10 @@ void main() {
       expect(summary.stats!.sampleCount, 0);
       expect(summary.stats!.avg, isNull);
       // The two timeouts plus the exit-code noReply are folded into errors.
-      expect(summary.errors.map((e) => e.error),
-          contains(ErrorType.requestTimedOut));
+      expect(
+        summary.errors.map((e) => e.error),
+        contains(ErrorType.requestTimedOut),
+      );
       expect(summary.errors.map((e) => e.error), contains(ErrorType.noReply));
     });
   });

--- a/test/stream_lifecycle_test.dart
+++ b/test/stream_lifecycle_test.dart
@@ -22,13 +22,13 @@ class FakeProcess implements Process {
     List<String> stdoutLines = const [],
     List<String> stderrLines = const [],
     required int exit,
-  })  : _stdout = Stream<List<int>>.fromIterable(
-          stdoutLines.map((l) => utf8.encode('$l\n')),
-        ),
-        _stderr = Stream<List<int>>.fromIterable(
-          stderrLines.map((l) => utf8.encode('$l\n')),
-        ),
-        _exitCode = Future<int>.value(exit);
+  }) : _stdout = Stream<List<int>>.fromIterable(
+         stdoutLines.map((l) => utf8.encode('$l\n')),
+       ),
+       _stderr = Stream<List<int>>.fromIterable(
+         stderrLines.map((l) => utf8.encode('$l\n')),
+       ),
+       _exitCode = Future<int>.value(exit);
 
   final Stream<List<int>> _stdout;
   final Stream<List<int>> _stderr;
@@ -57,12 +57,10 @@ class FakeProcess implements Process {
 /// configured [FakeProcess] or a launch failure. All parsing and exit-code
 /// interpretation are inherited from [PingLinux] unchanged.
 class TestPing extends PingLinux {
-  TestPing({
-    FakeProcess? process,
-    Object? launchError,
-  })  : _process = process,
-        _launchError = launchError,
-        super('1.1.1.1', 5, 1000, 1000, 255, IpVersion.ipv4);
+  TestPing({FakeProcess? process, Object? launchError})
+    : _process = process,
+      _launchError = launchError,
+      super('1.1.1.1', 5, 1000, 1000, 255, IpVersion.ipv4);
 
   final FakeProcess? _process;
   final Object? _launchError;
@@ -123,11 +121,16 @@ void main() {
 
       final result = await _drain(ping);
 
-      expect(result.errors, hasLength(1),
-          reason: 'exactly one error event expected on launch failure');
+      expect(
+        result.errors,
+        hasLength(1),
+        reason: 'exactly one error event expected on launch failure',
+      );
       expect(result.errors.single.toString(), contains('ping binary'));
-      expect(result.errors.single.toString(),
-          contains('Could not find ping binary'));
+      expect(
+        result.errors.single.toString(),
+        contains('Could not find ping binary'),
+      );
       expect(result.doneCount, 1, reason: 'stream must close exactly once');
     });
 
@@ -145,10 +148,15 @@ void main() {
 
       final result = await _drain(ping);
 
-      expect(result.errors, isNotEmpty,
-          reason: 'unmapped non-zero exit must surface an error');
-      expect(result.errors.first.toString(),
-          contains('Ping process exited with code: 2'));
+      expect(
+        result.errors,
+        isNotEmpty,
+        reason: 'unmapped non-zero exit must surface an error',
+      );
+      expect(
+        result.errors.first.toString(),
+        contains('Ping process exited with code: 2'),
+      );
       expect(result.doneCount, 1, reason: 'stream must close exactly once');
     });
 
@@ -166,8 +174,11 @@ void main() {
 
       final result = await _drain(ping);
 
-      expect(result.errors, isEmpty,
-          reason: 'a clean run must not surface an error');
+      expect(
+        result.errors,
+        isEmpty,
+        reason: 'a clean run must not surface an error',
+      );
       expect(result.doneCount, 1, reason: 'stream must close exactly once');
 
       final responses = result.data.whereType<PingResponse>().toList();
@@ -190,32 +201,42 @@ void main() {
       expect(summary.errors, isEmpty);
     });
 
-    test('(b2) a typed noRoute event AND the unmapped-exit error both surface',
-        () async {
-      // A noRoute line surfaces a typed PingError(noRoute) and the process
-      // also exits non-zero (2, unmapped). The unmapped-exit error is still
-      // surfaced — the exit code is an independent signal from the parsed line,
-      // so it is NOT suppressed (suppressing it would also hide a distinct exit
-      // after unrelated timeouts). The stream still closes exactly once.
-      final ping = TestPing(
-        process: FakeProcess(
-          stderrLines: const ['connect: Network is unreachable'],
-          exit: 2,
-        ),
-      );
+    test(
+      '(b2) a typed noRoute event AND the unmapped-exit error both surface',
+      () async {
+        // A noRoute line surfaces a typed PingError(noRoute) and the process
+        // also exits non-zero (2, unmapped). The unmapped-exit error is still
+        // surfaced — the exit code is an independent signal from the parsed line,
+        // so it is NOT suppressed (suppressing it would also hide a distinct exit
+        // after unrelated timeouts). The stream still closes exactly once.
+        final ping = TestPing(
+          process: FakeProcess(
+            stderrLines: const ['connect: Network is unreachable'],
+            exit: 2,
+          ),
+        );
 
-      final result = await _drain(ping);
+        final result = await _drain(ping);
 
-      final errorData = result.data.whereType<PingError>().toList();
-      expect(errorData, hasLength(1));
-      expect(errorData.single.error, ErrorType.noRoute,
-          reason: 'the routing failure surfaces as a typed PingError event');
-      expect(result.errors, hasLength(1),
-          reason: 'the unmapped exit still surfaces a catchable error');
-      expect(result.errors.single.toString(),
-          contains('Ping process exited with code: 2'));
-      expect(result.doneCount, 1, reason: 'stream must close exactly once');
-    });
+        final errorData = result.data.whereType<PingError>().toList();
+        expect(errorData, hasLength(1));
+        expect(
+          errorData.single.error,
+          ErrorType.noRoute,
+          reason: 'the routing failure surfaces as a typed PingError event',
+        );
+        expect(
+          result.errors,
+          hasLength(1),
+          reason: 'the unmapped exit still surfaces a catchable error',
+        );
+        expect(
+          result.errors.single.toString(),
+          contains('Ping process exited with code: 2'),
+        );
+        expect(result.doneCount, 1, reason: 'stream must close exactly once');
+      },
+    );
 
     group('(d) close-exactly-once across terminal paths', () {
       test('normal completion closes once', () async {
@@ -290,9 +311,7 @@ void main() {
     });
   });
 
-  group(
-      'bad-interface error-then-close (§spec:interface-platform-rejection)',
-      () {
+  group('bad-interface error-then-close (§spec:interface-platform-rejection)', () {
     // A chosen interface / source address that does not exist (or has no
     // connectivity) is NOT a new failure mode: the OS `ping` binary refuses
     // the bind and exits non-zero. That non-zero exit is already routed
@@ -304,13 +323,10 @@ void main() {
     // surfaced verbatim as an exit exception. The live-hardware variant is
     // the manual @Tags(['live']) path and stays out of scope here.
 
-    test('bad interface (refused bind) emits error then closes once',
-        () async {
+    test('bad interface (refused bind) emits error then closes once', () async {
       final ping = TestPing(
         process: FakeProcess(
-          stderrLines: const [
-            'ping: SO_BINDTODEVICE: No such device',
-          ],
+          stderrLines: const ['ping: SO_BINDTODEVICE: No such device'],
           exit: 2,
         ),
       );
@@ -319,45 +335,54 @@ void main() {
 
       // (1) The consumer receives at least one catchable error event, and it
       // is the surfaced exit exception (its text contains the exit code).
-      expect(result.errors, isNotEmpty,
-          reason: 'a refused bind / non-existent interface must surface an '
-              'error on the stream');
-      expect(result.errors.first.toString(),
-          contains('Ping process exited with code: 2'));
+      expect(
+        result.errors,
+        isNotEmpty,
+        reason:
+            'a refused bind / non-existent interface must surface an '
+            'error on the stream',
+      );
+      expect(
+        result.errors.first.toString(),
+        contains('Ping process exited with code: 2'),
+      );
 
       // (2) The stream then closes exactly once within the hard timeout —
       // no hang.
       expect(result.doneCount, 1, reason: 'stream must close exactly once');
     });
 
-    test('bad source address (cannot assign) emits error then closes once',
-        () async {
+    test(
+      'bad source address (cannot assign) emits error then closes once',
+      () async {
+        final ping = TestPing(
+          process: FakeProcess(
+            stderrLines: const ['ping: bind: Cannot assign requested address'],
+            exit: 2,
+          ),
+        );
+
+        final result = await _drain(ping);
+
+        expect(
+          result.errors,
+          isNotEmpty,
+          reason:
+              'a source address with no connectivity must surface an '
+              'error on the stream',
+        );
+        expect(
+          result.errors.first.toString(),
+          contains('Ping process exited with code: 2'),
+        );
+        expect(result.doneCount, 1, reason: 'stream must close exactly once');
+      },
+    );
+
+    test('awaiting consumer returns within timeout on bad interface', () async {
       final ping = TestPing(
         process: FakeProcess(
-          stderrLines: const [
-            'ping: bind: Cannot assign requested address',
-          ],
-          exit: 2,
-        ),
-      );
-
-      final result = await _drain(ping);
-
-      expect(result.errors, isNotEmpty,
-          reason: 'a source address with no connectivity must surface an '
-              'error on the stream');
-      expect(result.errors.first.toString(),
-          contains('Ping process exited with code: 2'));
-      expect(result.doneCount, 1, reason: 'stream must close exactly once');
-    });
-
-    test('awaiting consumer returns within timeout on bad interface',
-        () async {
-      final ping = TestPing(
-        process: FakeProcess(
-          stderrLines: const [
-            'ping: SO_BINDTODEVICE: No such device',
-          ],
+          stderrLines: const ['ping: SO_BINDTODEVICE: No such device'],
           exit: 2,
         ),
       );
@@ -400,11 +425,18 @@ void main() {
 
       // (finding 3) A terminal PingSummary is emitted and is the FINAL event.
       final summaries = result.data.whereType<PingSummary>().toList();
-      expect(summaries, hasLength(1),
-          reason: 'a terminal summary must be emitted even without a native '
-              'summary line');
-      expect(result.data.last, isA<PingSummary>(),
-          reason: 'the summary is the final event of the run');
+      expect(
+        summaries,
+        hasLength(1),
+        reason:
+            'a terminal summary must be emitted even without a native '
+            'summary line',
+      );
+      expect(
+        result.data.last,
+        isA<PingSummary>(),
+        reason: 'the summary is the final event of the run',
+      );
 
       // (finding 2) Counts are reconstructed consistently: received equals the
       // successful-reply sample count, transmitted adds the one probe failure,
@@ -412,16 +444,23 @@ void main() {
       // reply.
       final summary = summaries.single;
       expect(summary.received, 1);
-      expect(summary.received, summary.stats?.sampleCount,
-          reason: 'received must equal the stats sample count');
-      expect(summary.transmitted, 2,
-          reason: '1 reply + 1 timed-out probe');
+      expect(
+        summary.received,
+        summary.stats?.sampleCount,
+        reason: 'received must equal the stats sample count',
+      );
+      expect(summary.transmitted, 2, reason: '1 reply + 1 timed-out probe');
       expect(summary.packetLoss, 50.0);
-      expect(summary.time, isNull,
-          reason: 'no OS wall-clock without the native summary line');
+      expect(
+        summary.time,
+        isNull,
+        reason: 'no OS wall-clock without the native summary line',
+      );
       // The unmapped exit still surfaces a catchable error.
-      expect(result.errors.single.toString(),
-          contains('Ping process exited with code: 2'));
+      expect(
+        result.errors.single.toString(),
+        contains('Ping process exited with code: 2'),
+      );
       expect(result.doneCount, 1);
     });
 
@@ -439,9 +478,13 @@ void main() {
       final result = await _drain(ping);
 
       final summaries = result.data.whereType<PingSummary>().toList();
-      expect(summaries, hasLength(1),
-          reason: 'a clean run with no parsed summary line still terminates '
-              'with a PingSummary');
+      expect(
+        summaries,
+        hasLength(1),
+        reason:
+            'a clean run with no parsed summary line still terminates '
+            'with a PingSummary',
+      );
       expect(result.data.last, isA<PingSummary>());
       final summary = summaries.single;
       expect(summary.received, 1);


### PR DESCRIPTION
Pre-release review pass for **10.0.0**. The package, tests, and docs were already in good shape (`dart analyze --fatal-infos` clean, 238 non-live tests passing, CHANGELOG/README accurate); this PR cleans up the packaging and hygiene items found in review.

## Changes

**Packaging**
- Add `.pubignore` excluding `SPEC.md` (177 KB) and `REQUIREMENTS.md` (102 KB) — internal governance docs that dominated the published archive and add no value for consumers. Published archive **237 KB → 149 KB**. They stay in the repo.

**Formatting** (`d25c579`, isolated commit)
- `dart format .` across lib/hook/test. The sources had been formatted with the pre-3.7 *short* style, but the package targets Dart ≥3.10 whose formatter uses the *tall* style — so `dart format` was dirty and pana would dock formatting points. No behavior change; reviewable separately from the substantive commit.

**Docs / hygiene**
- Fix stale `DartPingIOS` doc reference in `address_family.dart` → `IosPing` (that type was removed in 10.0.0; iOS now constructs `IosPing` directly).
- README: clarify that `stream.first` yields a `PingEvent` (possibly a `PingError`), not necessarily a successful reply.
- pubspec: add `ios` topic.
- analysis_options: refresh the stale "pedantic/Google" lint comment and dead linter-rules URL.

## Verification
- `dart analyze --fatal-infos` → clean
- `dart format --set-exit-if-changed` → clean
- `dart test -x live` → 238 passing
- `dart pub publish --dry-run` → 0 package warnings

## Not included
- **Security: command injection via `host` on the Windows `forceCodepage` path** — filed as #90 to track separately. It's opt-in, Windows-only, and not a 10.0.0 regression, so it isn't a release blocker.
- A `dart format --set-exit-if-changed` CI step (would prevent the formatting drift from recurring) — happy to add if wanted.