### PR TITLE
feat: macOS all-timeout run yields a summary instead of throwing (#92)

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -80,6 +80,14 @@ This document tracks the following areas of work:
   ping inside background isolates (#48), without losing pure-Dart support on
   hosts with no Flutter SDK. Folds into the unreleased `dart_ping` 10.0.0
   train. Captured in the `§req:consolidation-*` sections at the end.
+- **macOS all-timeout summary (#92)** — on macOS, a run where every probe
+  times out but the first hop returns TTL-exceeded ICMP errors makes the
+  native `ping` exit with code `2`, which `PingMac` leaves unmapped, so
+  the consumer gets a thrown exception instead of the 100%-loss summary
+  already built. Map exit `2` to the same `noReply` outcome as exit `1`
+  (pure silence) so an all-timeout run deterministically yields a summary.
+  Refines `§req:robustness-*` without weakening its unmapped-exit
+  guarantee. Captured in the `§req:mac-all-timeout-*` sections at the end.
 
 ---
 
@@ -1883,3 +1891,150 @@ mechanism and feasibility are decided:
 - **Migration surface.** The precise consumer-facing migration (removing
   the `dart_ping_ios` dependency, deleting `register()`, any import
   changes) and how `dart_ping_ios` is marked discontinued on pub.dev.
+
+---
+
+# macOS all-timeout summary (#92)
+
+A focused robustness refinement in `dart_ping`'s macOS exit-code
+handling. On macOS, a run where every probe times out but the first
+hop returns TTL-exceeded ICMP errors makes the native `ping` exit with
+code `2`, which `PingMac` leaves unmapped — so the consumer gets a
+generic thrown exception instead of the 100%-loss `PingSummary` that
+was already built. The driver is GitHub issue #92.
+
+## macOS all-timeout — problem statement §req:mac-all-timeout-problem-statement
+
+The target users are developers consuming `dart_ping`'s `Ping` stream
+on macOS — typically with `await for`, `.drain()`, `.last`, or by
+awaiting `stop()` — who expect the run to finish with a terminal
+`PingSummary` they can read, even when every probe failed.
+
+On macOS, when a run elicits **no echo replies but does draw ICMP
+error packets back** — the classic `ttl=1` / TTL-exceeded case — the
+native `ping` binary exits with code **2**. The per-probe timeouts and
+TTL-exceeded errors are already captured correctly and a complete
+100%-loss `PingSummary` is already built, but exit `2` is not mapped to
+a known outcome, so the run instead surfaces a generic
+`Exception('Ping process exited with code: 2')`. A consumer awaiting the
+terminal summary (`stream.last`) gets that exception instead of the
+summary:
+
+```dart
+final ping = Ping('201.202.203.204', count: 2, ttl: 1);
+final event = await ping.stream.last; // throws instead of yielding a summary
+```
+
+This is **environment-dependent**, which is the deeper problem. macOS
+BSD `ping` exits `2` when it receives ICMP errors but no echo replies,
+and `1` on pure silence. Exit `1` is already mapped to `noReply` (a
+clean summary, no throw); exit `2` is not. So the *same* logical
+outcome — "we got no reply" — sometimes yields a summary and sometimes
+throws, depending only on whether the first hop happened to return a
+TTL-exceeded packet. That non-determinism is why the existing
+`TTL Exceeded` test is tagged `live` and excluded from CI, where it
+would otherwise be flaky.
+
+Current behavior fails these users because an all-timeout macOS run is
+a normal, expected diagnostic result — "the host did not answer" — and
+they should be able to read that off a summary, not have to catch a
+generic exception that double-reports a failure the per-probe error
+list already records.
+
+This refines, and does not contradict, the stream-lifecycle robustness
+work (`§req:robustness-success-criteria`): that guarantee — an
+*unmapped* non-zero exit surfaces a catchable error and closes the
+stream — still holds for genuinely unknown codes. This requirement
+moves macOS exit `2` out of the "unmapped" bucket and into a known
+outcome, so it is no longer governed by that throw-an-error rule.
+
+## macOS all-timeout — success criteria §req:mac-all-timeout-success-criteria
+
+Observable, end-to-end outcomes a tester can demonstrate against the
+`Ping` stream on macOS:
+
+- **An all-timeout run yields a summary, not an exception.** A macOS run
+  in which every probe fails and the host (or first hop) returns ICMP
+  errors but no echo replies terminates with a `PingSummary` event
+  reporting 100% packet loss — the consumer's `stream.last` returns that
+  summary rather than throwing. *(must-have)*
+- **The outcome is deterministic.** The same all-timeout run yields a
+  summary regardless of whether the network returned TTL-exceeded ICMP
+  errors (exit `2`) or pure silence (exit `1`) — both "no echo reply"
+  exit codes resolve to the same observable result. *(must-have)*
+- **The summary carries an honest error record.** The terminal summary's
+  error list contains the per-probe errors actually observed
+  (`requestTimedOut` / `timeToLiveExceeded`) plus a run-level `noReply`,
+  matching the shape a pure-silence (exit `1`) run already produces
+  today. No synthetic or duplicate error beyond that is introduced.
+  *(must-have)*
+- **Genuinely unmapped exits still surface an error.** A macOS `ping`
+  exit code that is neither a success nor a recognized "no reply" code
+  still surfaces a catchable error and closes the stream, preserving
+  `§req:robustness-success-criteria`. *(must-have — regression guard)*
+- **Normal runs are unchanged.** A successful macOS run (zero exit) and
+  a recognized error exit (e.g. unknown host) deliver the same per-probe
+  responses, summary, and error list as before. *(must-have — regression
+  guard)*
+- **The all-timeout path is covered without a live network.** The
+  previously `live`-only TTL-exceeded case is exercised by an automated
+  test that asserts a summary is produced (not an exception) and runs
+  under `dart test` without excluding it via `-x live`. *(high)*
+
+## macOS all-timeout — user stories §req:mac-all-timeout-user-stories
+
+- As a developer running a macOS ping that gets no replies, I want the
+  run to finish with a 100%-loss summary I can read so that "the host did
+  not answer" is a normal result I handle, not an exception I have to
+  catch.
+- As a developer setting `ttl=1` (or otherwise drawing TTL-exceeded
+  errors) on macOS, I want the same summary I would get from a silent
+  timeout so that my code behaves the same regardless of what the
+  intermediate hop returns.
+- As a developer awaiting `stream.last` / `.drain()` on macOS, I want an
+  all-timeout run to return a terminal summary so that my code does not
+  throw on a perfectly ordinary "no reply" outcome.
+- As an existing `dart_ping` user, I want genuinely unrecognized macOS
+  exit codes to keep surfacing a catchable error so that this change does
+  not weaken the robustness guarantees I already rely on.
+
+## macOS all-timeout — quality attributes §req:mac-all-timeout-quality-attributes
+
+- **Reliability / determinism:** the observable outcome of an
+  all-timeout macOS run does not depend on environment-specific ICMP
+  behavior — the same logical result (no reply) produces the same event
+  (a 100%-loss summary) every time.
+- **Compatibility:** the public API is unchanged — the `Ping` interface
+  and the `PingData` / `PingResponse` / `PingSummary` / `PingError`
+  shapes stay the same. The summary's error list for this path matches
+  the existing exit-`1` (pure-silence) shape, so consumers already
+  handling a no-reply run need no changes.
+- **Testability:** the all-timeout case is verifiable under `dart test`
+  without a live network, removing the `live`-only flakiness that hid
+  the bug from CI.
+
+## macOS all-timeout — constraints §req:mac-all-timeout-constraints
+
+- The change is internal to the macOS subprocess path
+  (`lib/src/ping/mac_ping.dart`, with lifecycle in
+  `lib/src/ping/base_ping.dart`); no change to the public API.
+- **macOS only.** Exit `2` is specific to BSD `ping` semantics; Windows
+  and Linux use different exit codes and output paths and are explicitly
+  out of scope for this requirement.
+- This is a **non-breaking, patch-level** change to `dart_ping`.
+- Must preserve `§req:robustness-success-criteria`: the "unmapped
+  non-zero exit surfaces an error, then closes" guarantee continues to
+  hold for codes that are not recognized "no reply" codes.
+
+## macOS all-timeout — priorities §req:mac-all-timeout-priorities
+
+- **Must-have:** macOS exit `2` yields a deterministic 100%-loss summary
+  (not a thrown exception) for an all-timeout run, with the no-reply
+  outcome reflected in the summary's error list exactly as exit `1`
+  already does, and genuinely unmapped exits still surfacing a catchable
+  error.
+- **High priority:** an automated, non-`live` test covering the
+  all-timeout / TTL-exceeded path so the previously environment-dependent
+  case is gated in CI.
+- **Nice-to-have:** none beyond the above — this is a focused robustness
+  refinement.

--- a/SPEC.md
+++ b/SPEC.md
@@ -48,7 +48,7 @@ This document covers the following areas, matching REQUIREMENTS.md:
   §spec:ios-error-parity, §spec:ios-ttl, §spec:stats-ios) while replacing the
   binding mechanism and the package boundary of §spec:spm-distribution.
 - **macOS all-timeout summary (#92)** — `§spec:mac-all-timeout-summary`
-  at the very end (not started). A focused refinement of
+  at the very end (implemented). A focused refinement of
   `§spec:stream-lifecycle-robustness`: a macOS run where every probe
   times out but the first hop returns TTL-exceeded ICMP errors (native
   exit `2`) yields a deterministic 100%-loss summary instead of a thrown
@@ -2674,7 +2674,7 @@ environment-dependent non-determinism is why the existing TTL-exceeded
 test is tagged `live` and excluded from CI, where it would be flaky.
 
 ## macOS all-timeout yields a summary §spec:mac-all-timeout-summary
-*Status: not started*
+*Status: implemented*
 
 On macOS, a run in which every probe fails terminates with a terminal
 `PingSummary` reporting 100% packet loss — never a thrown exception —

--- a/SPEC.md
+++ b/SPEC.md
@@ -47,6 +47,12 @@ This document covers the following areas, matching REQUIREMENTS.md:
   and preserves its observable behavior (§spec:ios-ping-behavior,
   §spec:ios-error-parity, §spec:ios-ttl, §spec:stats-ios) while replacing the
   binding mechanism and the package boundary of §spec:spm-distribution.
+- **macOS all-timeout summary (#92)** — `§spec:mac-all-timeout-summary`
+  at the very end (not started). A focused refinement of
+  `§spec:stream-lifecycle-robustness`: a macOS run where every probe
+  times out but the first hop returns TTL-exceeded ICMP errors (native
+  exit `2`) yields a deterministic 100%-loss summary instead of a thrown
+  exception, matching the pure-silence (exit `1`) outcome.
 
 Solution-space design for issue #73 — native, Swift Package Manager
 (SPM)-compatible iOS support for `dart_ping`.
@@ -2641,3 +2647,108 @@ raised SDK floor; they continue to work over the channel implementation
 rather than waiting for a future major, because 10.0.0 is already a breaking
 release (§spec:stats-event-model) and `register()`-removal and the SDK-floor
 raise are breaking changes best shipped once, together.
+
+---
+
+# macOS all-timeout summary
+
+Solution-space design for issue #92 (`§req:mac-all-timeout-*`), a
+focused refinement of the stream-lifecycle robustness work
+(`§spec:stream-lifecycle-robustness`). The work is confined to the
+core `dart_ping` package's macOS subprocess path and changes no public
+surface; it is independent of the iOS, stats, and consolidation areas.
+
+The problem (from §req:mac-all-timeout-problem-statement): on macOS,
+the BSD `ping` binary exits with code `2` when a run draws ICMP error
+packets back but no echo replies — the classic `ttl=1` / TTL-exceeded
+case — and with code `1` on pure silence. The macOS exit-code mapping
+recognizes `1` as a no-reply outcome but leaves `2` unmapped, so the
+*same* logical result — "we got no reply" — sometimes terminates with
+a clean 100%-loss `PingSummary` and sometimes surfaces a generic
+`Exception('Ping process exited with code: 2')`, depending only on
+whether an intermediate hop happened to return a TTL-exceeded packet.
+A consumer awaiting the terminal summary (`stream.last`, `.drain()`,
+`await for`, `stop()`) gets the exception on the exit-`2` path even
+though a complete 100%-loss summary was already built. That
+environment-dependent non-determinism is why the existing TTL-exceeded
+test is tagged `live` and excluded from CI, where it would be flaky.
+
+## macOS all-timeout yields a summary §spec:mac-all-timeout-summary
+*Status: not started*
+
+On macOS, a run in which every probe fails terminates with a terminal
+`PingSummary` reporting 100% packet loss — never a thrown exception —
+regardless of whether the network returned TTL-exceeded ICMP errors or
+pure silence. The macOS exit-code mapping treats "no echo reply"
+(native exit `1` *and* exit `2`) as a single recognized `noReply`
+outcome, so both resolve to the same observable result. This refines
+§spec:stream-lifecycle-robustness by moving macOS exit `2` out of its
+"unmapped non-zero exit" bucket and into a known outcome; the public
+API and the `PingData` / `PingResponse` / `PingSummary` / `PingError`
+shapes are unchanged (§spec:public-api-stability,
+§req:mac-all-timeout-quality-attributes — compatibility).
+
+- When a macOS run elicits no echo replies but draws ICMP errors back
+  (native exit `2`), the stream shall terminate with a `PingSummary`
+  event reporting 100% packet loss, and a consumer's `stream.last`
+  shall return that summary rather than throwing
+  (§req:mac-all-timeout-success-criteria,
+  §req:mac-all-timeout-user-stories).
+- The observable outcome of an all-timeout macOS run shall not depend
+  on whether the network returned TTL-exceeded errors (exit `2`) or
+  pure silence (exit `1`): both shall resolve to the same 100%-loss
+  summary (§req:mac-all-timeout-success-criteria — determinism;
+  §req:mac-all-timeout-quality-attributes — reliability).
+- The terminal summary's `errors` list for the exit-`2` path shall
+  carry the per-probe errors actually observed (`requestTimedOut` /
+  `timeToLiveExceeded`) plus a run-level `noReply`, matching the shape
+  a pure-silence (exit `1`) run already produces — no synthetic or
+  duplicate error beyond that, and in particular no generic
+  process-exit exception alongside the summary
+  (§req:mac-all-timeout-success-criteria — honest error record).
+- A macOS `ping` exit code that is neither a success nor a recognized
+  "no reply" code (`1` / `2`) nor a recognized error code shall still
+  surface a catchable error and then close the stream, preserving
+  §spec:stream-lifecycle-robustness
+  (§req:mac-all-timeout-success-criteria — regression guard;
+  §req:mac-all-timeout-constraints).
+- A successful macOS run (zero exit) and a recognized error exit (e.g.
+  unknown host) shall deliver the same per-probe responses, summary,
+  and `errors` list as before
+  (§req:mac-all-timeout-success-criteria — regression guard).
+- The all-timeout / TTL-exceeded path shall be covered by an automated
+  test that asserts a summary is produced (not an exception) and runs
+  under `dart test` without a live network and without being excluded
+  via `-x live` (§req:mac-all-timeout-success-criteria — coverage;
+  §req:mac-all-timeout-quality-attributes — testability).
+
+**Why map exit `2` to `noReply` rather than catch it specially:** the
+stream lifecycle already builds a complete 100%-loss summary from the
+observed per-probe errors and only throws because the exit code is
+unmapped. Mapping exit `2` to the same `noReply` outcome as exit `1`
+both records the run-level no-reply in the summary's `errors` list and
+suppresses the generic exit exception — because a recognized exit-code
+error short-circuits the unmapped-exit throw path. The summary that
+was already assembled simply becomes the terminal event, with no new
+machinery (§req:mac-all-timeout-problem-statement). A bespoke "catch
+exit 2 and synthesize a summary" path was rejected as redundant: it
+would duplicate the summary-building the lifecycle already performs and
+risk diverging from the exit-`1` shape consumers already handle.
+
+**Why this does not weaken robustness:** §spec:stream-lifecycle-robustness
+guarantees that an *unmapped* non-zero exit surfaces a catchable error
+and closes the stream. This section reclassifies exactly one code —
+macOS exit `2` — as a recognized no-reply outcome; every code that
+remains unmapped still flows through the unchanged throw-then-close
+path. The guarantee narrows by one well-understood code, it does not
+loosen (§req:mac-all-timeout-constraints).
+
+**Why macOS-only and patch-level:** exit `2` is specific to BSD `ping`
+semantics; Windows and Linux use different exit codes and output paths
+and are out of scope (§req:mac-all-timeout-constraints). The change is
+internal to the macOS subprocess path (`lib/src/ping/mac_ping.dart`,
+with the existing lifecycle in `lib/src/ping/base_ping.dart`), the
+public API and normal-run output are unchanged, and the no-reply
+summary surfaces through the stream consumers already use — so it ships
+as a non-breaking, patch-level change to `dart_ping`
+(§req:mac-all-timeout-constraints, §req:mac-all-timeout-priorities).

--- a/lib/src/ping/mac_ping.dart
+++ b/lib/src/ping/mac_ping.dart
@@ -107,15 +107,15 @@ class PingMac extends BasePing implements Ping {
 
   @override
   Exception? throwExit(int exitCode) {
-    // Recognized codes (`1`/`2` no-reply, `68` unknown host) are handled by
-    // interpretExitCode and must not surface a generic exit exception; every
-    // other non-success code remains an unmapped throw so a genuinely unknown
-    // failure still surfaces a catchable error then closes the stream
-    // (§spec:stream-lifecycle-robustness — the guarantee narrows by exactly the
-    // one well-understood exit `2`, it does not loosen).
-    const recognized = {1, 2, 68};
-
-    return exitCode != 0 && !recognized.contains(exitCode)
+    // A code that interpretExitCode recognizes (`1`/`2` no-reply, `68` unknown
+    // host) must not also surface a generic exit exception, so derive "should I
+    // throw?" from interpretExitCode rather than re-listing those codes here —
+    // interpretExitCode stays the single source of truth and the two cannot
+    // drift. Every other non-success code remains an unmapped throw so a
+    // genuinely unknown failure still surfaces a catchable error then closes the
+    // stream (§spec:stream-lifecycle-robustness — the guarantee narrows by
+    // exactly the one well-understood exit `2`, it does not loosen).
+    return exitCode != 0 && interpretExitCode(exitCode) == null
         ? Exception('Ping process exited with code: $exitCode')
         : null;
   }

--- a/lib/src/ping/mac_ping.dart
+++ b/lib/src/ping/mac_ping.dart
@@ -88,7 +88,15 @@ class PingMac extends BasePing implements Ping {
 
   @override
   PingError? interpretExitCode(int exitCode) {
-    if (exitCode == 1) {
+    // BSD `ping` reports "no echo reply" with TWO exit codes: `1` on pure
+    // silence and `2` when the run drew ICMP errors back but no replies (the
+    // classic `ttl=1` / TTL-exceeded case). Both are the same logical outcome,
+    // so both map to a single recognized `noReply`. Because a recognized
+    // exit-code error short-circuits base_ping's unmapped-exit throw path, the
+    // already-assembled 100%-loss summary becomes the terminal event instead of
+    // a thrown `Exception('Ping process exited with code: 2')`
+    // (§spec:mac-all-timeout-summary).
+    if (exitCode == 1 || exitCode == 2) {
       return PingError(.noReply);
     } else if (exitCode == 68) {
       return PingError(.unknownHost);
@@ -99,7 +107,15 @@ class PingMac extends BasePing implements Ping {
 
   @override
   Exception? throwExit(int exitCode) {
-    return exitCode > 1 && exitCode != 68
+    // Recognized codes (`1`/`2` no-reply, `68` unknown host) are handled by
+    // interpretExitCode and must not surface a generic exit exception; every
+    // other non-success code remains an unmapped throw so a genuinely unknown
+    // failure still surfaces a catchable error then closes the stream
+    // (§spec:stream-lifecycle-robustness — the guarantee narrows by exactly the
+    // one well-understood exit `2`, it does not loosen).
+    const recognized = {1, 2, 68};
+
+    return exitCode != 0 && !recognized.contains(exitCode)
         ? Exception('Ping process exited with code: $exitCode')
         : null;
   }

--- a/test/platform_test.dart
+++ b/test/platform_test.dart
@@ -131,17 +131,26 @@ void main() {
       expect(ping.locale, {'LC_ALL': 'C'});
     });
 
-    test('interpretExitCode maps 1/68 and ignores the rest', () {
+    test('interpretExitCode maps 1/2/68 and ignores the rest', () {
+      // BSD `ping` reports "no echo reply" with BOTH exit 1 (pure silence) and
+      // exit 2 (ICMP errors back, e.g. TTL-exceeded), so both map to noReply
+      // (§spec:mac-all-timeout-summary).
       expect(ping.interpretExitCode(1)?.error, ErrorType.noReply);
+      expect(ping.interpretExitCode(2)?.error, ErrorType.noReply);
       expect(ping.interpretExitCode(68)?.error, ErrorType.unknownHost);
       expect(ping.interpretExitCode(0), isNull);
-      expect(ping.interpretExitCode(2), isNull);
+      expect(ping.interpretExitCode(3), isNull);
     });
 
-    test('throwExit ignores 1 and 68 but throws for other failures', () {
-      expect(ping.throwExit(2), isA<Exception>());
+    test('throwExit ignores 1/2/68 but throws for genuinely-unmapped codes', () {
+      // Exit 2 is now a recognized no-reply outcome, so it no longer throws.
+      expect(ping.throwExit(2), isNull);
       expect(ping.throwExit(68), isNull);
       expect(ping.throwExit(1), isNull);
+      expect(ping.throwExit(0), isNull);
+      // A genuinely-unmapped code still surfaces a catchable exception
+      // (§spec:stream-lifecycle-robustness).
+      expect(ping.throwExit(3), isA<Exception>());
     });
 
     test('interface name appends -b <name> (boundif) as separate tokens', () {

--- a/test/stream_lifecycle_test.dart
+++ b/test/stream_lifecycle_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:dart_ping/dart_ping.dart';
 import 'package:dart_ping/src/ping/linux_ping.dart';
+import 'package:dart_ping/src/ping/mac_ping.dart';
 import 'package:test/test.dart';
 
 /// Hard ceiling for every awaited completion. A hung stream never closes, so
@@ -74,6 +75,20 @@ class TestPing extends PingLinux {
     : _process = process,
       _launchError = launchError,
       super('1.1.1.1', 5, 1000, 1000, 255, .ipv4);
+}
+
+/// [PingMac] subclass that replaces the OS process launch with a configured
+/// [FakeProcess]. All parsing and exit-code interpretation are inherited from
+/// [PingMac] unchanged, so the macOS exit-`1`/`2` mapping is exercised with NO
+/// network and NO subprocess — and therefore WITHOUT the `live` tag that hid
+/// the exit-`2` flakiness from CI (§spec:mac-all-timeout-summary).
+class MacTestPing extends PingMac {
+  final FakeProcess _process;
+  @override
+  Future<Process> get platformProcess async => _process;
+
+  MacTestPing(this._process)
+    : super('1.1.1.1', 5, 1000, 1000, 255, .ipv4);
 }
 
 /// Result of draining a ping stream to completion.
@@ -495,5 +510,186 @@ void main() {
       expect(result.errors, isEmpty);
       expect(result.doneCount, 1);
     });
+  });
+
+  group('macOS all-timeout summary (§spec:mac-all-timeout-summary)', () {
+    test(
+      'exit 2 (TTL-exceeded) yields a 100%-loss summary, never an exception',
+      () async {
+        // BSD `ping` exits 2 when a run drew ICMP errors back (TTL-exceeded)
+        // but no echo replies. Previously this surfaced
+        // `Exception('Ping process exited with code: 2')`; now exit 2 maps to
+        // a recognized `noReply`, so the already-built 100%-loss summary is the
+        // terminal event and NO exit exception is thrown.
+        final ping = MacTestPing(
+          FakeProcess(
+            stdoutLines: const [
+              '92 bytes from 172.17.0.1: Time to live exceeded',
+              '92 bytes from 172.17.0.1: Time to live exceeded',
+              '2 packets transmitted, 0 packets received',
+            ],
+            exit: 2,
+          ),
+        );
+
+        final result = await _drain(ping);
+
+        // No thrown exception reaches the consumer.
+        expect(
+          result.errors,
+          isEmpty,
+          reason:
+              'exit 2 is a recognized no-reply outcome — no generic '
+              'process-exit exception',
+        );
+
+        // The terminal event is a 100%-loss summary.
+        final summaries = result.data.whereType<PingSummary>().toList();
+        expect(summaries, hasLength(1), reason: 'one run summary expected');
+        expect(result.data.last, isA<PingSummary>());
+        final summary = summaries.single;
+        expect(summary.transmitted, 2);
+        expect(summary.received, 0);
+        expect(summary.packetLoss, 100.0);
+
+        // errors carries the per-probe TTL-exceeded events plus the run-level
+        // noReply — the same shape the exit-1 path produces, no duplicate.
+        final errorTypes = summary.errors.map((e) => e.error).toList();
+        expect(
+          errorTypes,
+          containsAll(const [
+            ErrorType.timeToLiveExceeded,
+            ErrorType.noReply,
+          ]),
+        );
+        expect(
+          errorTypes.where((e) => e == ErrorType.noReply),
+          hasLength(1),
+          reason: 'exactly one run-level noReply, not a duplicate',
+        );
+        expect(result.doneCount, 1, reason: 'stream must close exactly once');
+      },
+    );
+
+    test(
+      'exit 1 (pure silence) yields the same 100%-loss summary shape',
+      () async {
+        // Pure silence: every probe times out, the run exits 1. This is the
+        // shape the exit-2 path must match — the observable outcome of an
+        // all-timeout run does NOT depend on whether the network returned
+        // TTL-exceeded errors (exit 2) or silence (exit 1).
+        final ping = MacTestPing(
+          FakeProcess(
+            stdoutLines: const [
+              'Request timeout for icmp_seq 0',
+              'Request timeout for icmp_seq 1',
+              '2 packets transmitted, 0 packets received',
+            ],
+            exit: 1,
+          ),
+        );
+
+        final result = await _drain(ping);
+
+        expect(result.errors, isEmpty);
+        final summaries = result.data.whereType<PingSummary>().toList();
+        expect(summaries, hasLength(1));
+        expect(result.data.last, isA<PingSummary>());
+        final summary = summaries.single;
+        expect(summary.packetLoss, 100.0);
+
+        final errorTypes = summary.errors.map((e) => e.error).toList();
+        expect(
+          errorTypes,
+          containsAll(const [
+            ErrorType.requestTimedOut,
+            ErrorType.noReply,
+          ]),
+        );
+        expect(
+          errorTypes.where((e) => e == ErrorType.noReply),
+          hasLength(1),
+        );
+        expect(result.doneCount, 1);
+      },
+    );
+
+    test(
+      'regression: a genuinely-unmapped macOS exit still throws then closes',
+      () async {
+        // Exit 3 is neither success, nor a recognized no-reply (1/2), nor a
+        // recognized error code (68). It must still surface a catchable error
+        // and close the stream — §spec:stream-lifecycle-robustness narrows by
+        // exactly one code, it does not loosen.
+        final ping = MacTestPing(
+          FakeProcess(
+            stdoutLines: const [
+              '64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=10.1 ms',
+            ],
+            exit: 3,
+          ),
+        );
+
+        final result = await _drain(ping);
+
+        expect(
+          result.errors,
+          isNotEmpty,
+          reason: 'an unmapped exit must surface a catchable error',
+        );
+        expect(
+          result.errors.first.toString(),
+          contains('Ping process exited with code: 3'),
+        );
+        expect(result.doneCount, 1, reason: 'stream must close exactly once');
+      },
+    );
+
+    test('regression: a clean zero-exit macOS run is unchanged', () async {
+      final ping = MacTestPing(
+        FakeProcess(
+          stdoutLines: const [
+            '64 bytes from 1.1.1.1: icmp_seq=0 ttl=57 time=10.1 ms',
+            '5 packets transmitted, 5 packets received',
+          ],
+          exit: 0,
+        ),
+      );
+
+      final result = await _drain(ping);
+
+      expect(result.errors, isEmpty);
+      final summary = result.data.whereType<PingSummary>().single;
+      expect(summary.transmitted, 5);
+      expect(summary.received, 5);
+      expect(summary.packetLoss, 0.0);
+      expect(summary.errors, isEmpty);
+      expect(result.doneCount, 1);
+    });
+
+    test(
+      'regression: a recognized error exit (unknown host, 68) is unchanged',
+      () async {
+        final ping = MacTestPing(
+          FakeProcess(
+            stderrLines: const [
+              'ping: cannot resolve myUnknownHost: Unknown host',
+            ],
+            exit: 68,
+          ),
+        );
+
+        final result = await _drain(ping);
+
+        // No thrown exit exception — 68 is a recognized error code.
+        expect(result.errors, isEmpty);
+        final summary = result.data.whereType<PingSummary>().single;
+        expect(
+          summary.errors.map((e) => e.error),
+          contains(ErrorType.unknownHost),
+        );
+        expect(result.doneCount, 1);
+      },
+    );
   });
 }

--- a/test/stream_lifecycle_test.dart
+++ b/test/stream_lifecycle_test.dart
@@ -596,6 +596,10 @@ void main() {
         expect(summaries, hasLength(1));
         expect(result.data.last, isA<PingSummary>());
         final summary = summaries.single;
+        // Pin the same count fields the exit-2 test pins, so "same shape"
+        // covers transmitted/received and not just packetLoss.
+        expect(summary.transmitted, 2);
+        expect(summary.received, 0);
         expect(summary.packetLoss, 100.0);
 
         final errorTypes = summary.errors.map((e) => e.error).toList();


### PR DESCRIPTION
## What this builds

On macOS, BSD `ping` exits with code `2` when a run draws ICMP error packets back but no echo replies (the classic `ttl=1` / TTL-exceeded case), and code `1` on pure silence. `PingMac` mapped exit `1` → `noReply` but left exit `2` unmapped, so the *same* logical "no reply" outcome sometimes terminated with a clean 100%-loss `PingSummary` (exit 1) and sometimes surfaced `Exception('Ping process exited with code: 2')` (exit 2) — depending only on whether an intermediate hop happened to return a TTL-exceeded packet. A consumer awaiting `stream.last` / `.drain()` got the exception on the exit-`2` path even though a complete 100%-loss summary was already built.

This reclassifies macOS exit `2` as a recognized `noReply` outcome, so an all-timeout macOS run **always** terminates with a deterministic 100%-loss summary, never a thrown exception.

- `lib/src/ping/mac_ping.dart`:
  - `interpretExitCode` now maps **both** exit `1` and exit `2` to `PingError(noReply)`.
  - `throwExit` is derived from `interpretExitCode` (`exitCode != 0 && interpretExitCode(exitCode) == null`) so `interpretExitCode` is the single source of truth — the throw-list and no-reply-list cannot drift. Every code that is *not* a recognized no-reply/error code still surfaces a catchable exception, preserving the stream-lifecycle-robustness guarantee (it narrows by exactly one well-understood code, it does not loosen).
- The summary's `errors` list carries the per-probe errors actually observed (`requestTimedOut` / `timeToLiveExceeded`) plus a single run-level `noReply` — identical in shape to the exit-`1` path, no synthetic/duplicate error.
- macOS-only, patch-level, **no public API change**.

## §spec: sections now complete

- `§spec:mac-all-timeout-summary` — status flipped from *not started* → *implemented* in `SPEC.md`. Refines `§spec:stream-lifecycle-robustness` by moving macOS exit `2` out of the "unmapped non-zero exit" bucket into a known outcome.

## Integration test path for the reviewer

The previously `live`-only TTL-exceeded case is now covered deterministically (no live network, runs in the CI gate under `dart test -x live`) in `test/stream_lifecycle_test.dart` → group `macOS all-timeout summary (§spec:mac-all-timeout-summary)`:

- `exit 2 (TTL-exceeded) yields a 100%-loss summary, never an exception` — terminal event is a `PingSummary` with `transmitted=2, received=0, packetLoss=100%`; `errors` = `[timeToLiveExceeded…, noReply]` with exactly one `noReply`; stream closes once; no exception on the error channel.
- `exit 1 (pure silence) yields the same 100%-loss summary shape` — determinism guard; pins the same count fields.
- `regression: a genuinely-unmapped macOS exit still throws then closes` (exit 3) — preserves robustness.
- `regression:` clean zero-exit run and recognized error exit (unknown host, 68) are unchanged.
- Unit truth table in `test/platform_test.dart`: `interpretExitCode` maps 1/2/68; `throwExit` ignores 1/2/68 and throws for genuinely-unmapped codes.

Run locally: `dart analyze --fatal-infos && dart test -x live` (243 tests pass). Manual acceptance on macOS: `Ping('201.202.203.204', count: 2, ttl: 1).stream.last` now returns a 100%-loss summary instead of throwing.

## Review note

An automated code review was already completed in kandev during the Review step (see the task's plan artifact, "Code review — macOS all-timeout summary (#92)"): verdict clean — no correctness bugs, no spec violations; one LOW test-completeness finding was resolved (commit `1dc085f`). CI core gate (analyze + `dart test -x live`) is green; the Swift/iOS `xcodebuild` job runs on the GitHub macOS runner (not runnable on the Linux planning host; #92 touches no iOS/Swift code).