### PR TITLE
feat: host injection safety (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,16 @@ consumers who cannot adopt the raised floor.
 
 ### Fixed
 
+- **Host command-injection safety (#90).** A `host` is now validated as a
+  syntactically valid hostname or IPv4/IPv6 literal before anything launches; an
+  unsafe value throws an `ArgumentError` on every platform and both the default
+  and Windows `forceCodepage` launch paths, so a `host` can never reach a shell
+  as code (closing a `cmd.exe` breakout on the `forceCodepage` path) and is
+  never read by the subprocess as an option flag. The allow-list rejects shell
+  metacharacters, whitespace, and control characters, and — being shaped like a
+  hostname/IP literal — also rejects leading/trailing-hyphen values (e.g. `-f`,
+  `--flood`) and bracketed IPv6 (`[::1]`; use the unbracketed `::1`). Every
+  valid host pings exactly as before.
 - **Stream lifecycle robustness (#76).** The `Ping` stream could hang forever
   on a process-launch failure (e.g. a missing `ping` binary) or an unmapped
   non-zero exit code. Both now surface a catchable error through the stream's

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -2038,3 +2038,159 @@ Observable, end-to-end outcomes a tester can demonstrate against the
   case is gated in CI.
 - **Nice-to-have:** none beyond the above — this is a focused robustness
   refinement.
+
+---
+
+# Host injection safety (#90)
+
+A security fix in how `dart_ping` launches the native `ping` process.
+On the Windows-only `forceCodepage: true` path the library runs the
+process through `cmd.exe`, and a `host` value carrying shell
+metacharacters can break out and run an arbitrary command. The driver
+is GitHub issue #90, filed during the 10.0.0 pre-release review.
+
+## Host injection — problem statement §req:host-injection-problem-statement
+
+The target users are developers consuming `dart_ping` whose `host`
+value is, or could be, influenced by something outside their own code —
+a config file, a saved profile, a UI text field, an API response, a
+diagnostics tool that pings whatever address a user types. They expect
+that asking the library to ping a string only ever pings (or fails to
+ping) that string — never that the string could make their process run
+some *other* program.
+
+On one path that expectation breaks. When a caller opts into
+`forceCodepage: true` (a Windows-only switch that fixes garbled output
+by setting the console codepage to 437 before pinging — see
+`§req:windows-roundtrip-problem-statement`), the library starts the
+ping process *through the Windows command shell* rather than handing the
+arguments straight to the OS. The shell treats certain characters in the
+`host` — `&`, `|`, `<`, `>`, `^` — as command separators and redirects.
+The escaping the platform applies to each argument does not neutralize
+those characters, so a `host` like `8.8.8.8&calc` or `x|whoami` is read
+by the shell as "ping this, *then* run that." The injected command runs
+with the privileges of the calling process.
+
+The only existing check on `host` confirms that an IP *literal*'s family
+matches the requested family (`§req:ipfamily-problem-statement`); a
+hostname-shaped string laced with metacharacters sails straight through.
+On Windows the `interface` value is already constrained to an IP literal,
+so the practical untrusted vector is `host`.
+
+This is not a regression in 10.0.0 — `forceCodepage` predates this
+release — but it is a real, high-severity hole worth closing now. Its
+reach is constrained: it is **Windows only**, fires **only** when the
+caller has turned on `forceCodepage` (off by default), and requires the
+caller to be feeding in an untrusted `host`. The default path and all of
+Linux/macOS hand arguments directly to the OS with no shell in between,
+so they are not exposed. But where it does apply, the cost is the worst
+kind — silent, attacker-controlled code execution — and the surface
+(a diagnostics library that pings user-supplied targets) is exactly
+where untrusted hosts show up. The guarantee a user needs is simple and
+absolute: a `host` value is data, never a command.
+
+## Host injection — success criteria §req:host-injection-success-criteria
+
+Observable, verifiable outcomes a tester can demonstrate:
+
+- **A metacharacter host never executes anything.** With
+  `forceCodepage: true` on Windows, pinging a `host` such as
+  `8.8.8.8&calc`, `x|whoami`, `a>b`, or `a^b` does not launch, spawn, or
+  run any program other than the ping itself. No side effect, no injected
+  process — on this path or any other. *(must-have)*
+- **A dangerous host fails fast and clearly.** When a `host` contains
+  characters that cannot be carried safely to the ping process, the
+  caller gets a single, catchable error before the ping stream starts —
+  a thrown `ArgumentError` that names the problem (an unsafe/invalid host
+  value) — rather than a silent run, a hang, or a misleading network
+  error. This mirrors the fail-fast rejection already used for
+  address-family mismatches (`§req:ipfamily-success-criteria`).
+  *(must-have)*
+- **The guarantee holds on every path, not just the exploitable one.**
+  The "a host is data, never a command" guarantee is stated and upheld
+  across all platforms and both the default and `forceCodepage` paths —
+  not patched only where it currently bites. A tester can confirm the
+  same rejection behavior regardless of platform or flag. *(must-have)*
+- **Legitimate hosts are unaffected.** Ordinary hostnames and IPv4/IPv6
+  literals — including the `forceCodepage` happy path — ping exactly as
+  they do today, with the same responses, summary, and errors. The fix
+  is invisible to every valid target. *(must-have — regression guard)*
+- **The hole is covered by automated tests.** Injection attempts on the
+  `forceCodepage` path, and the rejection of metacharacter hosts, each
+  have a test that fails if an injected command could run or if a
+  dangerous host is accepted — runnable under `dart test` without a live
+  network. *(high)*
+
+## Host injection — user stories §req:host-injection-user-stories
+
+- As a developer building a network-diagnostics tool that pings whatever
+  address a user types, I want a host value to only ever be treated as a
+  ping target so that a malicious entry can never make my app run another
+  program.
+- As a developer who turns on `forceCodepage` to fix garbled Windows
+  output, I want that switch to carry no security cost so that opting into
+  readable output does not open a command-injection hole.
+- As a developer passing a host that came from config or an API, when the
+  value is unsafe I want a clear, catchable error before anything runs so
+  that I can reject it and log it rather than discover an injected command
+  after the fact.
+- As an existing `dart_ping` user, I want every valid host I ping today to
+  keep working unchanged so that this security fix is invisible to my
+  working code.
+
+## Host injection — quality attributes §req:host-injection-quality-attributes
+
+- **Security:** an untrusted `host` (and `interface`) value can never be
+  interpreted as a command or reach a shell as code. Host input is data.
+  This is the defining attribute of this work.
+- **Reliability:** a rejected host fails deterministically and fast — a
+  thrown error before the stream starts, never a hang or a swallowed
+  failure (consistent with `§req:robustness-success-criteria`).
+- **Compatibility:** the public API is unchanged in shape — the `Ping`
+  interface and `PingData` / `PingResponse` / `PingSummary` / `PingError`
+  types stay the same. Every valid host behaves byte-for-byte as before;
+  only inputs that were never valid hostnames/IPs are now refused.
+- **Testability:** injection and rejection are exercised by automated
+  tests that fail if a command could be injected or a dangerous host
+  accepted, without needing a live network or a real Windows shell.
+
+## Host injection — constraints §req:host-injection-constraints
+
+- The fix is internal to the core `dart_ping` package (the process-launch
+  path in `lib/src/ping/base_ping.dart` and host handling); no change to
+  the public API surface.
+- Refusing a `host` that carries shell metacharacters is treated as a
+  **security patch, not a breaking change** — such strings are not valid
+  hostnames or IP literals, and no legitimate caller relies on them.
+  Released as a patch-level change to `dart_ping`.
+- Scope is host-input safety on the process-launch path. Surfaced by, and
+  traceable to, the 10.0.0 pre-release review (issue #90) and related to
+  the `forceCodepage` behavior in `§req:windows-roundtrip-constraints` and
+  the untrusted-input hardening goal in `§req:robustness-constraints`.
+
+## Host injection — priorities §req:host-injection-priorities
+
+- **Must-have:** a `host` value can never execute a command on any path,
+  including Windows `forceCodepage`; unsafe hosts are rejected fast with a
+  catchable `ArgumentError` before the stream starts; every valid host
+  pings unchanged.
+- **High priority:** automated tests covering the `forceCodepage`
+  injection vector and the rejection of metacharacter hosts.
+- **Nice-to-have:** none beyond the above — this is a focused security
+  fix.
+
+## Host injection — open decisions §req:host-injection-open-decisions
+
+Surfaced during discovery and deferred to `/symphonize:plan`, where
+mechanism and feasibility are decided:
+
+- **Reject vs. never-shell, or both.** Whether safety comes from
+  validating/rejecting unsafe host values before launch, from removing the
+  shell from the `forceCodepage` path entirely (so the host never transits
+  `cmd.exe` — e.g. setting the codepage as a discrete prior step, or via
+  encoding), or from both as defense-in-depth. The required *outcome* (no
+  injection, fail-fast on unsafe input) is fixed; the mechanism is open.
+- **Exact rejection rule.** The precise definition of an "unsafe" host —
+  which characters/shapes are refused and how that rule stays correct
+  across platforms without rejecting any legitimate hostname or IP
+  literal.

--- a/SPEC.md
+++ b/SPEC.md
@@ -53,6 +53,13 @@ This document covers the following areas, matching REQUIREMENTS.md:
   times out but the first hop returns TTL-exceeded ICMP errors (native
   exit `2`) yields a deterministic 100%-loss summary instead of a thrown
   exception, matching the pure-silence (exit `1`) outcome.
+- **Host injection safety (#90)** — `§spec:host-input-is-data` …
+  `§spec:host-injection-tests` at the very end (implemented). A security
+  fix closing a command-injection hole on the Windows `forceCodepage`
+  path, where a `host` carrying shell metacharacters could break out of
+  `cmd.exe` and run an arbitrary command. A shared, cross-platform
+  fail-fast guard makes a `host` value data, never a command. Shipped as
+  a patch-level change.
 
 Solution-space design for issue #73 — native, Swift Package Manager
 (SPM)-compatible iOS support for `dart_ping`.
@@ -2752,3 +2759,194 @@ public API and normal-run output are unchanged, and the no-reply
 summary surfaces through the stream consumers already use — so it ships
 as a non-breaking, patch-level change to `dart_ping`
 (§req:mac-all-timeout-constraints, §req:mac-all-timeout-priorities).
+---
+
+# Host injection safety
+
+Solution-space design for issue #90 (`§req:host-injection-*`). A security
+fix closing a command-injection hole on the Windows `forceCodepage` path.
+
+The problem (from §req:host-injection-problem-statement): when a caller
+opts into `forceCodepage: true`, the library launches the ping process
+*through* `cmd.exe` (`runInShell` plus a `chcp 437 && ping …` chain). The
+shell interprets `&`, `|`, `<`, `>`, and `^` in arguments as command
+separators and redirections; per-argument escaping does not neutralize
+them. A `host` such as `8.8.8.8&calc` or `x|whoami` is therefore read by
+the shell as "ping this, *then* run that," executing an arbitrary command
+with the calling process's privileges. The only pre-existing input check
+on `host` validates an IP literal's address family
+(§spec:address-family-mismatch-validation); a hostname-shaped string laced
+with metacharacters passes straight through. The hole is Windows-only,
+fires only when `forceCodepage` is on (off by default), and needs an
+untrusted `host` — but where it applies the cost is silent,
+attacker-controlled code execution, and a diagnostics library that pings
+user-supplied targets is exactly where untrusted hosts appear.
+
+The two sections below place a single cross-platform guard so a `host`
+value can never reach a shell as code, and pin its automated coverage.
+The guarantee is deliberately stated and enforced on *every* path — all
+platforms, both the default and `forceCodepage` launch paths — not only
+where it currently bites (§req:host-injection-success-criteria).
+
+## A host value is data, never a command §spec:host-input-is-data
+*Status: implemented (dart_ping 10.0.0) — a shared `validateHostSafety(host)` allow-list guard (`lib/src/host_validation.dart`) accepts only a syntactically valid hostname or IPv4/IPv6 literal (incl. scoped/zoned IPv6 and ASCII/punycode IDN) and throws an `ArgumentError` for anything carrying shell metacharacters, whitespace, control characters, an option-flag shape (leading/trailing hyphen, e.g. `-f`), or bracketed-IPv6 URL notation (`[::1]`). The guard runs at the shared `Ping(...)` factory boundary AND in the platform/`IosPing` constructor path (alongside `validateAddressFamily`), so neither construction path can bypass it, on every platform and regardless of `forceCodepage`. Covered network-free in `test/host_injection_test.dart`.*
+
+A `host` value is only ever a ping target. It can never be interpreted as
+a command, and it never reaches a shell as code — on any platform, with or
+without `forceCodepage`. A `host` that is not a syntactically valid
+hostname or IP literal is rejected before anything launches, with a single
+catchable error, identical in shape on every platform.
+
+- When `host` contains a character that has no place in a hostname or IP
+  literal — shell metacharacters (`&`, `|`, `<`, `>`, `^`, `(`, `)`, `"`,
+  `'`, `` ` ``, `;`, `$`, `%`, backslash), whitespace, or any control
+  character — the system shall throw an `ArgumentError` that names an
+  unsafe/invalid host value, before the ping stream starts, identical in
+  shape across all platforms and regardless of `forceCodepage`
+  (§req:host-injection-success-criteria — fails fast and clearly, and
+  holds on every path; §req:host-injection-user-stories).
+- A `host` that is an ordinary hostname or an IPv4/IPv6 literal — including
+  IPv6 forms with `:` and scoped/zone notation, and ASCII/punycode
+  internationalized names — shall start the ping exactly as it does today,
+  on every platform and on the `forceCodepage` happy path, with the same
+  responses, summary, and errors (§req:host-injection-success-criteria —
+  legitimate hosts unaffected; §req:host-injection-quality-attributes —
+  compatibility).
+- The guard shall run at the shared `Ping(...)` factory boundary *and* in
+  the platform constructor path (alongside the existing address-family
+  guard), so neither the factory nor direct construction of a platform
+  class can bypass it (§req:host-injection-success-criteria — holds on
+  every path; §spec:address-family-mismatch-validation).
+- The same guarantee shall extend to any other launch-path value that
+  could transit the shell; on Windows `interface` is already constrained
+  to an IP literal (§spec:interface-platform-rejection), so the practical
+  untrusted vector is `host`, but the rule is "a launch input is data, not
+  code" rather than "sanitize `host`"
+  (§req:host-injection-quality-attributes — security).
+
+**Why reject with a synchronous `ArgumentError`, not a stream error
+event:** an unsafe `host` is a programming error in the *call*, knowable
+before any process launches and without a network. Surfacing it as a
+thrown `ArgumentError` lets the caller catch it at the call site and keeps
+it distinct from runtime network failures, which belong on the stream's
+error channel. This deliberately mirrors the address-family mismatch guard
+(§spec:address-family-mismatch-validation), which already rejects a
+bad-by-construction `host`/`ipVersion` pairing the same way — one more
+fail-fast reason on the same input, surfaced through the same mechanism,
+so callers learn one rejection model (§req:host-injection-quality-attributes
+— reliability; §req:robustness-success-criteria).
+
+**Why an allow-list of hostname/IP-literal characters, not a blacklist of
+shell metacharacters:** the guarantee must not depend on enumerating every
+character a shell treats specially — different shells differ, and a missed
+metacharacter silently reopens the hole. Defining what a *valid hostname
+or IP literal* may contain is a small, fixed, well-specified set; anything
+outside it is refused. A `host` that survives the allow-list contains no
+character `cmd.exe` (or any shell) could act on, so the surviving value is
+safe to launch *even through the existing shell path* — the safety comes
+from what the value is, not from how it is launched
+(§req:host-injection-open-decisions — exact rejection rule). The precise
+character set is an implementation detail; the observable contract is the
+two bullets above — every valid hostname and IPv4/IPv6 literal pings
+unchanged, everything else is refused.
+
+**Why the guard lives once in shared Dart, applied on every platform:**
+placing it at the `Ping(...)` boundary makes the rejection identical
+everywhere by construction, satisfying the must-have that the guarantee
+hold on every path, not only the exploitable Windows one
+(§req:host-injection-success-criteria). Restricting the check to the
+Windows `forceCodepage` path was rejected: it would leave the "host is
+data" guarantee unstated on the paths that happen to be safe today, so a
+future launch-path change (a new shelled step, a new platform) could
+reintroduce injection with no guard in place. A metacharacter `host` is
+not a valid target on any platform — on the non-shell paths it already
+fails as an unknown host — so rejecting it everywhere refuses nothing a
+legitimate caller relies on (§req:host-injection-constraints — security
+patch, not a breaking change).
+
+**Why this is a patch, not a breaking change:** the strings now refused —
+hosts carrying shell metacharacters or control characters — are not valid
+hostnames or IP literals, and no legitimate caller depends on them. The
+public API surface is unchanged (the `Ping` interface and
+`PingData`/`PingResponse`/`PingSummary`/`PingError` types are untouched);
+only never-valid inputs are now refused. It ships as a patch-level release
+of `dart_ping` (§req:host-injection-constraints;
+§req:host-injection-priorities).
+
+## The `forceCodepage` path carries no injection §spec:forcecodepage-injection-closed
+*Status: implemented (dart_ping 10.0.0) — closed by construction via §spec:host-input-is-data: a host that survives the allow-list contains no character `cmd.exe` could act on, so a metacharacter host (`8.8.8.8&calc`, `x|whoami`, `a>b`, `a^b`) is rejected before the `chcp 437 && ping …` shell chain is ever built. The shell launch was intentionally NOT removed (de-shelling deferred as future hardening; validation is the load-bearing mechanism). Pinned by tests asserting a metacharacter host produces no launchable `PingWindows` command/params with `forceCodepage: true`, and that the `forceCodepage` happy path is byte-for-byte unchanged.*
+
+On Windows with `forceCodepage: true`, a `host` carrying shell
+metacharacters launches, spawns, or runs nothing but the ping itself.
+Opting into readable Windows output (the codepage-437 round-trip,
+§req:windows-roundtrip-problem-statement) carries no security cost.
+
+- When `forceCodepage: true` on Windows and `host` is a metacharacter
+  string such as `8.8.8.8&calc`, `x|whoami`, `a>b`, or `a^b`, the system
+  shall run no program other than the ping — no injected process, no side
+  effect — and shall instead reject the call per §spec:host-input-is-data
+  before the stream starts (§req:host-injection-success-criteria —
+  metacharacter host never executes anything).
+- When `forceCodepage: true` and `host` is a legitimate hostname or IP
+  literal, the produced launch shall set codepage 437 and ping exactly as
+  it does today, with byte-for-byte identical observable behavior
+  (§req:host-injection-success-criteria — legitimate hosts unaffected,
+  including the `forceCodepage` happy path; §spec:windows-roundtrip-contract).
+
+**Why validation at the boundary suffices to close the shell path:** the
+injection exists because the host transits `cmd.exe` on this path, but the
+allow-list guard (§spec:host-input-is-data) removes from the host every
+character the shell could interpret *before* launch. A host that reaches
+the `chcp 437 && ping …` command line has already been proven to contain
+only hostname/IP-literal characters, so the shell has nothing to act on —
+the breakout is closed at the source, not patched at the launch site.
+
+**Why the shell launch was not removed outright (de-shelling considered
+and deferred):** removing `cmd.exe` from this path — e.g. setting the
+console output codepage through a Win32 FFI call (`SetConsoleOutputCP`)
+before spawning `ping`, so the `chcp … &&` chain and `runInShell` are gone
+— was weighed as defense-in-depth (§req:host-injection-open-decisions —
+reject vs. never-shell, or both). It is rejected for this focused security
+patch: it adds Windows-only native FFI for no additional safety, because
+the boundary guard already makes the surviving host inert to any shell. It
+would also not, on its own, satisfy the must-have that an unsafe host
+*fail fast* (§req:host-injection-success-criteria) — de-shelling alone
+would silently pass a malformed host to `ping`. Validation is therefore
+the load-bearing mechanism; de-shelling is left as a possible future
+hardening with no behavior the user could observe today.
+
+## Host-safety tests §spec:host-injection-tests
+*Status: implemented (dart_ping 10.0.0) — `test/host_injection_test.dart` runs network-free under `dart test` (no real Windows shell): metacharacter payloads rejected with the fail-fast `ArgumentError` independent of platform and `forceCodepage` (incl. via `PingWindows` constructed directly and the `Ping(...)` factory); the `forceCodepage` path builds no command for a metacharacter host; option-flag-shaped and bracketed-IPv6 hosts rejected; and regression guards assert ordinary hostnames and IPv4/IPv6 literals — including the `forceCodepage` happy path — produce the same command/params as before.*
+
+The injection vector and the rejection rule are pinned by automated tests
+that fail if an injected command could run or a dangerous host could be
+accepted, runnable under `dart test` with no live network and no real
+Windows shell (§req:host-injection-success-criteria — covered by automated
+tests; §req:host-injection-priorities — high).
+
+- A test shall assert that a metacharacter `host` is rejected with the
+  fail-fast `ArgumentError` of §spec:host-input-is-data — exercised for the
+  representative payloads (`8.8.8.8&calc`, `x|whoami`, `a>b`, `a^b`) and
+  asserted independent of platform and of `forceCodepage`, since the guard
+  is shared Dart over pure input (§req:host-injection-success-criteria —
+  rejection of metacharacter hosts; §spec:address-family-error-tests).
+- A test shall assert that on the `forceCodepage` path a metacharacter
+  `host` produces no launchable ping command — the dangerous value never
+  reaches the constructed command/launch — so an injected command could not
+  run even though no Windows shell executes in CI
+  (§req:host-injection-success-criteria — the `forceCodepage` injection
+  vector; §req:host-injection-quality-attributes — testability).
+- Regression-guard tests shall assert that ordinary hostnames and
+  IPv4/IPv6 literals — including the `forceCodepage` happy path — are
+  accepted and produce the same command/params as today
+  (§req:host-injection-success-criteria — legitimate hosts unaffected).
+
+**Why test through the public surface over pure input:** the guard is
+synchronous validation over a `host` string, so the injection and
+rejection are exercisable without spawning a process or a shell — the same
+network-free, deterministic approach the address-family tests use
+(§spec:address-family-error-tests). A test that needed a real `cmd.exe` to
+prove the breakout is closed would be unrunnable on the Linux CI host
+(§req:host-injection-quality-attributes — testability); asserting that the
+dangerous host is refused before any command is built proves the same
+property deterministically on every runner.

--- a/lib/dart_ping.dart
+++ b/lib/dart_ping.dart
@@ -6,6 +6,8 @@ export 'package:dart_ping/src/models/round_trip_stats.dart'
 export 'package:dart_ping/src/ip_version.dart';
 export 'package:dart_ping/src/address_family.dart'
     show ipLiteralFamily, validateAddressFamily;
+export 'package:dart_ping/src/host_validation.dart'
+    show isHostSafe, validateHostSafety;
 export 'package:dart_ping/src/ping_interface.dart';
 export 'package:dart_ping/src/models/ping_parser.dart';
 export 'package:dart_ping/src/interface_listing.dart'

--- a/lib/src/host_validation.dart
+++ b/lib/src/host_validation.dart
@@ -34,10 +34,15 @@ bool isHostSafe(String host) {
     return true;
   }
 
-  // A scoped/zoned IPv6 literal: `<ipv6>%<zone>`. `tryParse` rejects the zone
-  // suffix, so validate the two parts ourselves. This is the ONLY position in
-  // which `%` is admitted — a free-standing `%` (e.g. `8.8.8.8%calc`, `%VAR%`)
-  // does not reach a valid IPv6 body and is refused.
+  // A scoped/zoned IPv6 literal: `<ipv6>%<zone>`. `InternetAddress.tryParse`
+  // does accept zoned IPv6, but its zone handling is environment-dependent — it
+  // validates the zone against the host's actual scope ids, so `fe80::1%eth0`
+  // parses only where `eth0` exists. To accept a syntactically-valid scoped
+  // literal DETERMINISTICALLY (and portably, off the spawning host), validate
+  // the two parts ourselves: the body must parse as an IPv6 literal and the zone
+  // must be shell-safe. This is the ONLY position in which `%` is admitted — a
+  // free-standing `%` (e.g. `8.8.8.8%calc`, `%VAR%`) does not reach a valid IPv6
+  // body and is refused, and any zone carrying a metacharacter fails `_zoneId`.
   final pct = host.indexOf('%');
   if (pct > 0) {
     final body = host.substring(0, pct);

--- a/lib/src/host_validation.dart
+++ b/lib/src/host_validation.dart
@@ -1,9 +1,15 @@
 import 'dart:io';
 
-/// Matches a single hostname label: ASCII letters, digits, hyphen and
-/// underscore. Punycode/IDN labels (`xn--…`) are ASCII and therefore covered.
-/// No shell metacharacter, whitespace or control character can match.
-final RegExp _hostnameLabel = RegExp(r'^[A-Za-z0-9_-]+$');
+/// Matches a single hostname label: ASCII letters, digits, underscore, and
+/// interior hyphens. A label may NOT start or end with a hyphen (RFC 952/1123),
+/// which also prevents a host shaped like a `ping` option flag (e.g. `-f`,
+/// `-c1000000`, `--flood`): `host` is handed to the subprocess as an argument,
+/// so a leading-dash value would be read as a flag rather than a target —
+/// argument injection, adjacent to the shell-injection this guard closes.
+/// Punycode/IDN labels (`xn--…`) start with a letter and so are covered. No
+/// shell metacharacter, whitespace or control character can match.
+final RegExp _hostnameLabel =
+    RegExp(r'^[A-Za-z0-9_]([A-Za-z0-9_-]*[A-Za-z0-9_])?$');
 
 /// Matches an IPv6 zone/scope id (the part after `%` in `fe80::1%eth0`): an
 /// interface name or numeric index. Restricted to characters that are inert to
@@ -57,6 +63,12 @@ bool isHostSafe(String host) {
   // Otherwise it must be a syntactically valid hostname: dot-separated labels,
   // each a run of hostname-safe characters. A single trailing dot (the FQDN
   // root) is tolerated.
+  //
+  // Bracketed IPv6 (`[::1]`) is deliberately NOT accepted: the brackets are URL
+  // authority notation, not a bare ping target — `host` is passed verbatim to
+  // the subprocess, where `ping [::1]` fails as an unknown host on every
+  // platform. The unbracketed literal (`::1`) is the supported form (handled
+  // above). The `[`/`]` fail the label charset below, so such input is refused.
   final name =
       host.endsWith('.') ? host.substring(0, host.length - 1) : host;
   if (name.isEmpty || name.length > 253) return false;

--- a/lib/src/host_validation.dart
+++ b/lib/src/host_validation.dart
@@ -31,24 +31,18 @@ final RegExp _zoneId = RegExp(r'^[A-Za-z0-9_.-]+$');
 bool isHostSafe(String host) {
   if (host.isEmpty) return false;
 
-  // A clean IPv4/IPv6 literal (no zone). `InternetAddress.tryParse` accepts
-  // these and rejects anything with stray characters.
-  final literal = InternetAddress.tryParse(host);
-  if (literal != null &&
-      (literal.type == InternetAddressType.IPv4 ||
-          literal.type == InternetAddressType.IPv6)) {
-    return true;
-  }
-
-  // A scoped/zoned IPv6 literal: `<ipv6>%<zone>`. `InternetAddress.tryParse`
-  // does accept zoned IPv6, but its zone handling is environment-dependent — it
-  // validates the zone against the host's actual scope ids, so `fe80::1%eth0`
-  // parses only where `eth0` exists. To accept a syntactically-valid scoped
-  // literal DETERMINISTICALLY (and portably, off the spawning host), validate
-  // the two parts ourselves: the body must parse as an IPv6 literal and the zone
-  // must be shell-safe. This is the ONLY position in which `%` is admitted — a
-  // free-standing `%` (e.g. `8.8.8.8%calc`, `%VAR%`) does not reach a valid IPv6
-  // body and is refused, and any zone carrying a metacharacter fails `_zoneId`.
+  // A scoped/zoned IPv6 literal: `<ipv6>%<zone>`. This MUST be decided before
+  // the plain `InternetAddress.tryParse` below, because that parse's zone
+  // handling is environment-dependent: on macOS it accepts a zoned IPv6 with an
+  // arbitrary, UNVALIDATED zone string, so a dangerous zone such as
+  // `fe80::1%a&b` would parse as a valid IPv6 address and wrongly return `true`
+  // (on Linux/Windows the same parse is strict and returns null). Deciding every
+  // `%`-bearing host here — validating the two parts ourselves: the body must
+  // parse as an IPv6 literal and the zone must be shell-safe — makes the result
+  // DETERMINISTIC and portable across platforms. This is the ONLY position in
+  // which `%` is admitted: a free-standing `%` (e.g. `8.8.8.8%calc`, `%VAR%`)
+  // does not reach a valid IPv6 body and is refused, and any zone carrying a
+  // metacharacter fails `_zoneId`.
   final pct = host.indexOf('%');
   if (pct > 0) {
     final body = host.substring(0, pct);
@@ -58,6 +52,16 @@ bool isHostSafe(String host) {
         bodyAddr.type == InternetAddressType.IPv6 &&
         zone.isNotEmpty &&
         _zoneId.hasMatch(zone);
+  }
+
+  // A clean IPv4/IPv6 literal (no zone). `InternetAddress.tryParse` accepts
+  // these and rejects anything with stray characters. Any `%`-bearing host has
+  // already been decided above, so this only ever sees an unzoned candidate.
+  final literal = InternetAddress.tryParse(host);
+  if (literal != null &&
+      (literal.type == InternetAddressType.IPv4 ||
+          literal.type == InternetAddressType.IPv6)) {
+    return true;
   }
 
   // Otherwise it must be a syntactically valid hostname: dot-separated labels,

--- a/lib/src/host_validation.dart
+++ b/lib/src/host_validation.dart
@@ -1,0 +1,87 @@
+import 'dart:io';
+
+/// Matches a single hostname label: ASCII letters, digits, hyphen and
+/// underscore. Punycode/IDN labels (`xn--…`) are ASCII and therefore covered.
+/// No shell metacharacter, whitespace or control character can match.
+final RegExp _hostnameLabel = RegExp(r'^[A-Za-z0-9_-]+$');
+
+/// Matches an IPv6 zone/scope id (the part after `%` in `fe80::1%eth0`): an
+/// interface name or numeric index. Restricted to characters that are inert to
+/// any shell — `%` itself is admitted ONLY as the delimiter, never freely.
+final RegExp _zoneId = RegExp(r'^[A-Za-z0-9_.-]+$');
+
+/// Whether [host] is a syntactically valid hostname or IPv4/IPv6 literal and is
+/// therefore safe to launch as a ping target — data, never a command.
+///
+/// This is an ALLOW-LIST: a host passes only by matching a hostname or IP
+/// literal shape, so anything containing a character with no place in a
+/// hostname/IP literal — shell metacharacters (`&`, `|`, `<`, `>`, `^`, `(`,
+/// `)`, `"`, `'`, `` ` ``, `;`, `$`, `%`, backslash), whitespace, or any control
+/// character — is refused by construction. A blacklist of shell metacharacters
+/// is deliberately avoided: a single missed metacharacter would silently reopen
+/// the hole, and different shells differ (§spec:host-input-is-data).
+///
+/// Parse-only and network-free: no DNS resolution is performed.
+bool isHostSafe(String host) {
+  if (host.isEmpty) return false;
+
+  // A clean IPv4/IPv6 literal (no zone). `InternetAddress.tryParse` accepts
+  // these and rejects anything with stray characters.
+  final literal = InternetAddress.tryParse(host);
+  if (literal != null &&
+      (literal.type == InternetAddressType.IPv4 ||
+          literal.type == InternetAddressType.IPv6)) {
+    return true;
+  }
+
+  // A scoped/zoned IPv6 literal: `<ipv6>%<zone>`. `tryParse` rejects the zone
+  // suffix, so validate the two parts ourselves. This is the ONLY position in
+  // which `%` is admitted — a free-standing `%` (e.g. `8.8.8.8%calc`, `%VAR%`)
+  // does not reach a valid IPv6 body and is refused.
+  final pct = host.indexOf('%');
+  if (pct > 0) {
+    final body = host.substring(0, pct);
+    final zone = host.substring(pct + 1);
+    final bodyAddr = InternetAddress.tryParse(body);
+    return bodyAddr != null &&
+        bodyAddr.type == InternetAddressType.IPv6 &&
+        zone.isNotEmpty &&
+        _zoneId.hasMatch(zone);
+  }
+
+  // Otherwise it must be a syntactically valid hostname: dot-separated labels,
+  // each a run of hostname-safe characters. A single trailing dot (the FQDN
+  // root) is tolerated.
+  var name = host;
+  if (name.endsWith('.')) name = name.substring(0, name.length - 1);
+  if (name.isEmpty || name.length > 253) return false;
+  for (final label in name.split('.')) {
+    if (label.isEmpty || label.length > 63 || !_hostnameLabel.hasMatch(label)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Throws an [ArgumentError] when [host] is not a syntactically valid hostname
+/// or IP literal — i.e. when it carries a character that could be interpreted by
+/// a shell. A safe host returns normally; no DNS is performed.
+///
+/// Centralised here so every entry point — the [Ping] factory, the core
+/// platform classes (via `BasePing`), and the iOS `IosPing` constructor — fails
+/// fast with the identical error before any process launches, mirroring
+/// [validateAddressFamily]. This makes a `host` value data on every platform and
+/// both the default and `forceCodepage` launch paths, so a host reaching the
+/// Windows `chcp 437 && ping …` shell chain has already been proven inert
+/// (§spec:host-input-is-data, §spec:forcecodepage-injection-closed).
+void validateHostSafety(String host) {
+  if (!isHostSafe(host)) {
+    throw ArgumentError.value(
+      host,
+      'host',
+      'Unsafe or invalid host value: a host must be a syntactically valid '
+          'hostname or IPv4/IPv6 literal, and may not contain shell '
+          'metacharacters, whitespace, or control characters',
+    );
+  }
+}

--- a/lib/src/host_validation.dart
+++ b/lib/src/host_validation.dart
@@ -52,8 +52,8 @@ bool isHostSafe(String host) {
   // Otherwise it must be a syntactically valid hostname: dot-separated labels,
   // each a run of hostname-safe characters. A single trailing dot (the FQDN
   // root) is tolerated.
-  var name = host;
-  if (name.endsWith('.')) name = name.substring(0, name.length - 1);
+  final name =
+      host.endsWith('.') ? host.substring(0, host.length - 1) : host;
   if (name.isEmpty || name.length > 253) return false;
   for (final label in name.split('.')) {
     if (label.isEmpty || label.length > 63 || !_hostnameLabel.hasMatch(label)) {

--- a/lib/src/ping/base_ping.dart
+++ b/lib/src/ping/base_ping.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:async/async.dart';
 import 'package:dart_ping/src/address_family.dart';
+import 'package:dart_ping/src/host_validation.dart';
 import 'package:dart_ping/src/ip_version.dart';
 import 'package:dart_ping/src/models/ping_event.dart';
 import 'package:dart_ping/src/models/round_trip_stats.dart';
@@ -179,9 +180,14 @@ abstract class BasePing {
     this.interface,
     this.nat64Synthesis,
   ) {
-    // Enforce the literal/family guard on EVERY construction path, not only the
-    // `Ping(...)` factory — direct construction of a platform class must fail
-    // fast the same way (§spec:address-family-mismatch-validation).
+    // Enforce the host-safety and literal/family guards on EVERY construction
+    // path, not only the `Ping(...)` factory — direct construction of a platform
+    // class must fail fast the same way. The host-safety guard makes the value
+    // that ultimately reaches the Windows `chcp 437 && ping …` shell chain inert
+    // by construction (§spec:host-input-is-data,
+    // §spec:forcecodepage-injection-closed); the family guard rejects a
+    // literal/ipVersion mismatch (§spec:address-family-mismatch-validation).
+    validateHostSafety(host);
     validateAddressFamily(host, ipVersion);
     _controller = StreamController<PingEvent>(
       onListen: _onListen,

--- a/lib/src/ping/ios/ios_ping.dart
+++ b/lib/src/ping/ios/ios_ping.dart
@@ -4,6 +4,7 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 
 import 'package:dart_ping/src/address_family.dart';
+import 'package:dart_ping/src/host_validation.dart';
 import 'package:dart_ping/src/ip_version.dart';
 import 'package:dart_ping/src/models/ping_event.dart';
 import 'package:dart_ping/src/models/ping_parser.dart';
@@ -88,8 +89,9 @@ class IosPing implements Ping {
   set parser(PingParser value) => throw UnimplementedError();
 
   /// Creates an iOS ping bound to [host], mirroring the field set the channel
-  /// bridge carried. The address-family guard runs in the constructor — exactly
-  /// as every other platform does — so a literal IP whose family contradicts
+  /// bridge carried. The host-safety and address-family guards run in the
+  /// constructor — exactly as every other platform does — so an unsafe `host`
+  /// (§spec:host-input-is-data) or a literal IP whose family contradicts
   /// [ipVersion] fails fast with the identical [ArgumentError], regardless of
   /// whether the instance is ever listened to.
   IosPing(
@@ -101,6 +103,7 @@ class IosPing implements Ping {
     this._ipVersion,
     this._nat64Synthesis,
   ) {
+    validateHostSafety(_host);
     validateAddressFamily(_host, _ipVersion);
   }
 

--- a/lib/src/ping_interface.dart
+++ b/lib/src/ping_interface.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'address_family.dart';
+import 'host_validation.dart';
 import 'ip_version.dart';
 import 'models/ping_event.dart';
 import 'models/ping_parser.dart';
@@ -105,6 +106,15 @@ abstract class Ping {
     /// raw pass-through: the family-pinned resolve with no synthesis.
     bool nat64Synthesis = true,
   }) {
+    // Synchronous host-safety guard: a [host] is data, never a command. Reject
+    // any value that is not a syntactically valid hostname or IP literal — i.e.
+    // one carrying shell metacharacters, whitespace, or control characters —
+    // before anything launches, so a `host` can never reach a shell as code on
+    // any platform or on the Windows `forceCodepage` path (§spec:host-input-is-data).
+    // Checked first so a garbage string fails on the safety rule rather than
+    // slipping past the family parse below as an unclassified "hostname".
+    validateHostSafety(host);
+
     // Synchronous address-family guard: if [host] is a literal IP address, its
     // family MUST match the selected [ipVersion]. This runs before any platform
     // dispatch (including the iOS factory path) and before any stream/process

--- a/test/host_injection_test.dart
+++ b/test/host_injection_test.dart
@@ -80,27 +80,23 @@ void main() {
     // both flag values, plus through the public `Ping(...)` factory.
     group('rejection is independent of platform and forceCodepage', () {
       for (final host in const ['8.8.8.8&calc', 'x|whoami', 'a>b', 'a^b']) {
-        test('PingWindows($host) rejected with forceCodepage: false', () {
-          expect(
-            () => PingWindows(host, 1, 1, 2, 255, IpVersion.ipv4),
-            throwsArgumentError,
-          );
-        });
-
-        test('PingWindows($host) rejected with forceCodepage: true', () {
-          expect(
-            () => PingWindows(
-              host,
-              1,
-              1,
-              2,
-              255,
-              IpVersion.ipv4,
-              forceCodepage: true,
-            ),
-            throwsArgumentError,
-          );
-        });
+        for (final forceCodepage in const [false, true]) {
+          test('PingWindows($host) rejected with forceCodepage: $forceCodepage',
+              () {
+            expect(
+              () => PingWindows(
+                host,
+                1,
+                1,
+                2,
+                255,
+                IpVersion.ipv4,
+                forceCodepage: forceCodepage,
+              ),
+              throwsArgumentError,
+            );
+          });
+        }
 
         test('Ping($host) factory rejected before the stream starts', () {
           expect(() => Ping(host), throwsArgumentError);

--- a/test/host_injection_test.dart
+++ b/test/host_injection_test.dart
@@ -1,0 +1,168 @@
+import 'package:dart_ping/dart_ping.dart';
+import 'package:dart_ping/src/ping/windows_ping.dart';
+import 'package:test/test.dart';
+
+/// Host command-injection safety (#90).
+///
+/// The guard is synchronous validation over a `host` string, so the injection
+/// vector and the rejection rule are exercisable without spawning a process or a
+/// shell — network-free and deterministic on every runner, including the Linux
+/// CI host where no `cmd.exe` exists (§spec:host-injection-tests).
+void main() {
+  // Representative metacharacter payloads from the spec — each would break out
+  // of `cmd.exe` on the Windows `forceCodepage` path if it reached the shell.
+  const metacharHosts = <String>[
+    '8.8.8.8&calc',
+    'x|whoami',
+    'a>b',
+    'a^b',
+    'a<b',
+    r'a$b',
+    'a;b',
+    'a(b)c',
+    'a`b`c',
+    r'a\b',
+    'a b', // whitespace
+    'a\tb', // control character (tab)
+    'a\nb', // control character (newline)
+    '%VAR%', // bare percent (cmd.exe variable expansion)
+    '8.8.8.8%calc', // free-standing `%` that is not a valid IPv6 zone
+  ];
+
+  // Hosts that must keep working byte-for-byte after the fix.
+  const validHosts = <String>[
+    'example.com',
+    'sub.example.com',
+    'localhost',
+    'my-host_1.internal',
+    'xn--nxasmq6b.example.com', // punycode / IDN
+    'example.com.', // FQDN trailing dot
+    '8.8.8.8',
+    '127.0.0.1',
+  ];
+
+  group('Host injection safety (#90): ', () {
+    group('validateHostSafety rejects metacharacter / unsafe hosts', () {
+      for (final host in metacharHosts) {
+        test('rejects ${host.replaceAll('\n', r'\n').replaceAll('\t', r'\t')}',
+            () {
+          expect(() => validateHostSafety(host), throwsArgumentError);
+          expect(isHostSafe(host), isFalse);
+        });
+      }
+
+      test('rejects an empty host', () {
+        expect(() => validateHostSafety(''), throwsArgumentError);
+      });
+    });
+
+    group('validateHostSafety accepts valid hostnames and IP literals', () {
+      for (final host in validHosts) {
+        test('accepts $host', () {
+          expect(() => validateHostSafety(host), returnsNormally);
+          expect(isHostSafe(host), isTrue);
+        });
+      }
+
+      test('accepts IPv6 literals (selected with ipv6)', () {
+        // Family matching is enforced separately; here we only assert host
+        // SAFETY, so test the safety guard directly for IPv6 literals.
+        for (final host in const ['::1', '2001:db8::1', 'fe80::1%eth0']) {
+          expect(() => validateHostSafety(host), returnsNormally, reason: host);
+          expect(isHostSafe(host), isTrue, reason: host);
+        }
+      });
+    });
+
+    // The guard is shared Dart over a pure input, so rejection is independent of
+    // the host platform and of `forceCodepage`. We prove this by constructing
+    // the Windows platform class DIRECTLY — it runs on the Linux CI host — for
+    // both flag values, plus through the public `Ping(...)` factory.
+    group('rejection is independent of platform and forceCodepage', () {
+      for (final host in const ['8.8.8.8&calc', 'x|whoami', 'a>b', 'a^b']) {
+        test('PingWindows($host) rejected with forceCodepage: false', () {
+          expect(
+            () => PingWindows(host, 1, 1, 2, 255, IpVersion.ipv4),
+            throwsArgumentError,
+          );
+        });
+
+        test('PingWindows($host) rejected with forceCodepage: true', () {
+          expect(
+            () => PingWindows(
+              host,
+              1,
+              1,
+              2,
+              255,
+              IpVersion.ipv4,
+              forceCodepage: true,
+            ),
+            throwsArgumentError,
+          );
+        });
+
+        test('Ping($host) factory rejected before the stream starts', () {
+          expect(() => Ping(host), throwsArgumentError);
+        });
+      }
+    });
+
+    // §spec:forcecodepage-injection-closed — a metacharacter host on the
+    // forceCodepage path produces NO launchable ping command: construction
+    // throws, so the dangerous value never reaches `command` / `params`.
+    group('forceCodepage path builds no command for a metacharacter host', () {
+      for (final host in const ['8.8.8.8&calc', 'x|whoami', 'a>b', 'a^b']) {
+        test('no command/params are ever constructed for $host', () {
+          // The throw happens in the CONSTRUCTOR, so no `PingWindows` instance
+          // exists and `command` / `params` are never reachable with the
+          // dangerous value — the host cannot transit `chcp 437 && ping …`.
+          expect(
+            () => PingWindows(
+              host,
+              1,
+              1,
+              2,
+              255,
+              IpVersion.ipv4,
+              forceCodepage: true,
+            ),
+            throwsArgumentError,
+          );
+        });
+      }
+    });
+
+    // Regression guard: legitimate hosts — including the forceCodepage happy
+    // path — produce the SAME command/params as before the fix.
+    group('legitimate hosts are unaffected (byte-for-byte command/params)', () {
+      test('IPv4 literal, default flags', () {
+        final ping = PingWindows('8.8.8.8', 1, 1, 2, 255, IpVersion.ipv4);
+        expect(ping.params, ['-w', '2000', '-i', '255', '-4', '-n', '1']);
+        expect(ping.command, 'ping -w 2000 -i 255 -4 -n 1 8.8.8.8');
+      });
+
+      test('hostname, default flags', () {
+        final ping = PingWindows('example.com', 1, 1, 2, 255, IpVersion.ipv4);
+        expect(ping.command, 'ping -w 2000 -i 255 -4 -n 1 example.com');
+      });
+
+      test('forceCodepage happy path produces identical params/command', () {
+        final plain = PingWindows('8.8.8.8', 1, 1, 2, 255, IpVersion.ipv4);
+        final coded = PingWindows(
+          '8.8.8.8',
+          1,
+          1,
+          2,
+          255,
+          IpVersion.ipv4,
+          forceCodepage: true,
+        );
+        // forceCodepage changes the LAUNCH (chcp + runInShell), not the ping
+        // command string the host is interpolated into.
+        expect(coded.params, plain.params);
+        expect(coded.command, plain.command);
+      });
+    });
+  });
+}

--- a/test/host_injection_test.dart
+++ b/test/host_injection_test.dart
@@ -11,7 +11,7 @@ import 'package:test/test.dart';
 void main() {
   // Representative metacharacter payloads from the spec — each would break out
   // of `cmd.exe` on the Windows `forceCodepage` path if it reached the shell.
-  const metacharHosts = <String>[
+  final metacharHosts = <String>[
     '8.8.8.8&calc',
     'x|whoami',
     'a>b',
@@ -27,6 +27,9 @@ void main() {
     'a\nb', // control character (newline)
     '%VAR%', // bare percent (cmd.exe variable expansion)
     '8.8.8.8%calc', // free-standing `%` that is not a valid IPv6 zone
+    'fe80::1%a&b', // scoped IPv6 with a metacharacter in the zone id
+    'fe80::1%a;b', // scoped IPv6 with a metacharacter in the zone id
+    'a${'b' * 64}.com', // label longer than the 63-char limit
   ];
 
   // Hosts that must keep working byte-for-byte after the fix.
@@ -66,11 +69,25 @@ void main() {
 
       test('accepts IPv6 literals (selected with ipv6)', () {
         // Family matching is enforced separately; here we only assert host
-        // SAFETY, so test the safety guard directly for IPv6 literals.
-        for (final host in const ['::1', '2001:db8::1', 'fe80::1%eth0']) {
+        // SAFETY, so test the safety guard directly for IPv6 literals. Scoped
+        // IPv6 with a named or numeric zone must be accepted DETERMINISTICALLY —
+        // independent of whether the zone names a real interface on this host.
+        for (final host in const [
+          '::1',
+          '2001:db8::1',
+          '::ffff:1.2.3.4', // IPv4-mapped IPv6
+          'fe80::1%eth0', // named zone
+          'fe80::1%12', // numeric zone
+        ]) {
           expect(() => validateHostSafety(host), returnsNormally, reason: host);
           expect(isHostSafe(host), isTrue, reason: host);
         }
+      });
+
+      test('accepts a maximum-length (63-char) label', () {
+        final host = 'a${'b' * 62}.com'; // 63-char label
+        expect(() => validateHostSafety(host), returnsNormally);
+        expect(isHostSafe(host), isTrue);
       });
     });
 

--- a/test/host_injection_test.dart
+++ b/test/host_injection_test.dart
@@ -38,11 +38,30 @@ void main() {
     'sub.example.com',
     'localhost',
     'my-host_1.internal',
+    'a-b.example.com', // interior hyphen must keep passing
     'xn--nxasmq6b.example.com', // punycode / IDN
     'example.com.', // FQDN trailing dot
     '8.8.8.8',
     '127.0.0.1',
   ];
+
+  // Hosts shaped like a `ping` option flag. They contain no shell metacharacter,
+  // but `host` is handed to the subprocess as an argument, so a leading-dash
+  // value would be read as a flag rather than a target (argument injection). No
+  // valid hostname (RFC 952/1123 labels start alphanumeric) or IP literal starts
+  // or ends with a hyphen, so these are refused (§spec:host-input-is-data).
+  const optionFlagHosts = <String>[
+    '-f',
+    '-c1000000',
+    '--flood',
+    '-foo.com', // leading-dash label
+    'foo-.com', // trailing-dash label
+    '-', // bare hyphen
+  ];
+
+  // Bracketed IPv6 is URL authority notation, not a bare ping target; the
+  // unbracketed literal is the supported form. Deliberately rejected.
+  const bracketedHosts = <String>['[::1]', '[fe80::1%eth0]', '[2001:db8::1]'];
 
   group('Host injection safety (#90): ', () {
     group('validateHostSafety rejects metacharacter / unsafe hosts', () {
@@ -56,6 +75,33 @@ void main() {
 
       test('rejects an empty host', () {
         expect(() => validateHostSafety(''), throwsArgumentError);
+      });
+    });
+
+    group('rejects option-flag-shaped hosts (argument injection)', () {
+      for (final host in optionFlagHosts) {
+        test('rejects $host', () {
+          expect(() => validateHostSafety(host), throwsArgumentError);
+          expect(isHostSafe(host), isFalse);
+        });
+      }
+
+      test('Ping(-f) factory rejected before the stream starts', () {
+        expect(() => Ping('-f'), throwsArgumentError);
+      });
+    });
+
+    group('rejects bracketed IPv6 (use the unbracketed literal instead)', () {
+      for (final host in bracketedHosts) {
+        test('rejects $host', () {
+          expect(() => validateHostSafety(host), throwsArgumentError);
+          expect(isHostSafe(host), isFalse);
+        });
+      }
+
+      test('the unbracketed literal IS accepted', () {
+        expect(isHostSafe('::1'), isTrue);
+        expect(isHostSafe('fe80::1%eth0'), isTrue);
       });
     });
 


### PR DESCRIPTION
## Host injection safety (#90)

Closes the command-injection hole on the Windows `forceCodepage` path, where a `host` carrying shell metacharacters (`8.8.8.8&calc`, `x|whoami`, …) could break out of the `cmd.exe` `chcp 437 && ping …` chain and run an arbitrary command. The fix makes a `host` value **data, never a command** on every platform and both launch paths, shipped as a non-breaking, patch-level change folded into the unreleased 10.0.0 train.

### What was built
- **Shared allow-list guard** — new `lib/src/host_validation.dart` exposes `isHostSafe(host)` / `validateHostSafety(host)`. It accepts only a syntactically valid hostname or IPv4/IPv6 literal (including scoped/zoned IPv6 and ASCII/punycode IDN) and throws a fail-fast `ArgumentError` for anything else. It is an **allow-list, not a metacharacter blacklist**, so a missed shell metacharacter can't silently reopen the hole.
- **Wired at every construction path** — the guard runs at the shared `Ping(...)` factory boundary **and** in the platform/`IosPing` constructor path (alongside the existing `validateAddressFamily`), so neither the factory nor direct construction of a platform class can bypass it. Identical error shape on every platform, regardless of `forceCodepage`, before any stream/process starts.
- **forceCodepage closed by construction** — a host that survives the allow-list contains no character `cmd.exe` could act on, so the shell chain has nothing to interpret. (De-shelling was considered and deliberately deferred; validation is the load-bearing mechanism.)
- **Hardening from the in-kandev code review** (see below): the hostname-label rule forbids leading/trailing hyphens (RFC 952/1123), so an option-flag-shaped host (`-f`, `-c1000000`, `--flood`) can't be read by the subprocess as a flag (argument injection); bracketed-IPv6 URL notation (`[::1]`) is an explicit, documented rejection (use the unbracketed `::1`).
- **CHANGELOG** entry recording the security fix.

### §spec sections now complete
- `§spec:host-input-is-data` — the shared allow-list guard + wiring
- `§spec:forcecodepage-injection-closed` — Windows `forceCodepage` shell path proven inert
- `§spec:host-injection-tests` — network-free automated coverage

(SPEC.md / REQUIREMENTS.md status lines and the area overview are updated to "implemented".)

### Integration test path for the reviewer
All checks are network-free and need no real Windows shell — they run on the Linux/macOS/Windows CI matrix via `dart test -x live`:
- `dart analyze --fatal-infos` → clean
- `dart test -x live` → green (303 tests), including `test/host_injection_test.dart`
- Quick manual sanity:
  - `Ping('8.8.8.8&calc')`, `Ping('x|whoami')`, `Ping('-f')`, `Ping('[::1]')` → throw `ArgumentError` before the stream starts
  - `Ping('8.8.8.8')`, `Ping('example.com')`, `Ping('my-host.com')`, `Ping('::1')`, and the Windows `forceCodepage: true` happy path → unchanged, byte-for-byte identical command/params

### Note on review
An automated, multi-angle code review was already completed in the kandev Review step (recorded in the findings in the task's plan artifact, "Code review — host-injection (#90)"). Two findings (a MEDIUM leading-dash argument-injection gap and a LOW bracketed-IPv6 behavior change) were surfaced and **both resolved on this branch** before opening the PR; CI is green.