### PR TITLE
chore(release): trim pub topics to ping/icmp/network

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,9 +10,6 @@ topics:
   - ping
   - icmp
   - network
-  - networking
-  - latency
-  - ios
 
 environment:
   sdk: ">=3.10.0 <4.0.0"


### PR DESCRIPTION
Trims the `topics` list in `pubspec.yaml` from 6 entries to 3 (`ping`, `icmp`, `network`), dropping `networking`, `latency`, and `ios`. pub.dev allows at most 5 topics; this keeps the list within the limit and focused on the most relevant tags ahead of the 10.0.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)