### PR TITLE
release: unblock dart_ping publish — relocate hook gating helper + add publish-dry-run gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,12 @@ jobs:
   # --dry-run` validates the package archive without uploading anything and
   # without pub.dev credentials, so it runs deterministically on the Linux host
   # with no iOS SDK and no network publish step. It exits non-zero on any
-  # publish error — including pub's experimental "Hook files are experimental
-  # and <file> is not allowed yet" complaint — so a regression that puts a
-  # non-entrypoint file back into hook/, or otherwise breaks the archive, turns
-  # this check red on the PR that introduced it instead of surfacing at
-  # `dart pub publish`.
+  # publish error the client reports, so an archive/pubspec/structural break
+  # turns this check red on the PR that introduced it instead of surfacing at
+  # `dart pub publish`. (Note: on Dart 3.12.x the experimental
+  # "Hook files are experimental and <file> is not allowed yet" restriction is
+  # enforced server-side at publish, not by the client dry run — so a stray
+  # non-entrypoint file in hook/ is caught at `dart pub publish`, not here.)
   #
   # `if: github.base_ref == 'main'` scopes this to the develop->main release
   # path (§spec:ci-develop) — it does NOT run on feature PRs into develop, so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,34 @@ jobs:
       - run: dart analyze --fatal-infos
       - run: dart test -x live
 
+  # ---- Required on the RELEASE PATH only --------------------------------
+  # Publishability gate (§spec:publish-dry-run-check). `dart pub publish
+  # --dry-run` validates the package archive without uploading anything and
+  # without pub.dev credentials, so it runs deterministically on the Linux host
+  # with no iOS SDK and no network publish step. It exits non-zero on any
+  # publish error — including pub's experimental "Hook files are experimental
+  # and <file> is not allowed yet" complaint — so a regression that puts a
+  # non-entrypoint file back into hook/, or otherwise breaks the archive, turns
+  # this check red on the PR that introduced it instead of surfacing at
+  # `dart pub publish`.
+  #
+  # `if: github.base_ref == 'main'` scopes this to the develop->main release
+  # path (§spec:ci-develop) — it does NOT run on feature PRs into develop, so
+  # the per-feature gate is unchanged. One workflow file, gated by target
+  # branch, keeps a single source of truth.
+  publish-dry-run:
+    name: publish dry-run (release gate)
+    if: github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+      # --no-example mirrors the `core` job: the Flutter example/ is not
+      # resolvable on a Flutter-less runner, and the dry run validates the root
+      # dart_ping package archive, not the example subpackage.
+      - run: dart pub get --no-example
+      - run: dart pub publish --dry-run
+
   # The Swift ICMP framing/parse suite. Requires a macOS runner with Xcode and
   # an iOS simulator (#74). Building the example first generates the Flutter
   # artifacts the Runner target links against.

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ pubspec.lock
 
 # Conventional directory for build outputs
 build/
+# ...but lib/src/build/ holds the build-hook gating helper (source, not output).
+!lib/src/build/
 
 # Directory created by dartdoc
 doc/api/

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -2194,3 +2194,141 @@ mechanism and feasibility are decided:
   which characters/shapes are refused and how that rule stays correct
   across platforms without rejecting any legitimate hostname or IP
   literal.
+
+## Publishability — problem statement §req:publishable-problem-statement
+
+The target users are the package maintainers, who need to ship each
+release of `dart_ping` to pub.dev so that every developer who depends on
+the package can actually get it. A release that builds and tests cleanly
+but cannot be published is, from a consumer's point of view, no release
+at all.
+
+Publishing 10.0.0 is blocked. Running the publish command fails before
+the archive is ever uploaded, with:
+
+> Hook files are experimental and `hook/gating.dart` is not allowed yet.
+
+The cause is a collision between two things the package does. First,
+10.0.0 ships a native-asset *build hook* (`hook/build.dart`) that
+compiles the iOS ICMP engine into a code asset only for iOS targets
+(`§req:consolidation-problem-statement`,
+`§req:ipfamily-problem-statement`). Native-asset hooks are still an
+*experimental* pub feature, and while experimental, pub only permits the
+known hook entrypoint(s) — `hook/build.dart` — to live in the `hook/`
+directory; any other Dart file there is refused outright, and the refusal
+aborts the entire publish.
+
+Second, to keep the non-negotiable pure-Dart gate honest, the maintainers
+factored the "should this build emit the iOS code asset?" decision out of
+the hook into a small pure function in `hook/gating.dart`, so the gate is
+unit-testable offline on the Linux CI host where the Swift/iOS
+cross-compile itself cannot run (`§req:ci-develop-problem-statement`).
+That helper is good engineering, but it is a *non-entrypoint* file sitting
+inside `hook/`, which is exactly what the experimental-hooks rule forbids.
+
+The result: a release that passes analysis and the full offline test
+suite still cannot reach pub.dev. The maintainer hits the wall only at
+publish time — late, with a green build behind them — and has no way to
+ship without first understanding an opaque, experimental-feature
+restriction. As the package leans further on native-asset hooks, the
+risk of tripping this same class of wall again grows, so the need is not
+only to unblock 10.0.0 but to keep the package reliably publishable.
+
+## Publishability — success criteria §req:publishable-success-criteria
+
+Observable, verifiable outcomes a maintainer can demonstrate:
+
+- **The package passes a publish dry run.** Running
+  `dart pub publish --dry-run` from the package root reports no errors and,
+  specifically, no "Hook files are experimental and … is not allowed yet"
+  complaint. The maintainer can then publish manually. *(must-have)*
+- **`hook/` contains only permitted entrypoints.** The published `hook/`
+  directory holds only the hook file(s) pub allows under the experimental
+  rule (`hook/build.dart`); no helper, support, or test-only Dart file
+  remains in `hook/`. *(must-have)*
+- **The iOS code-asset build still works.** After the change, an iOS
+  target build still produces the `dart_ping_ffi` code asset, and every
+  non-iOS target (desktop/server, Android, the analyzer / `dart pub get`
+  path) still emits no code asset and invokes no native toolchain — the
+  pure-Dart gate is unchanged (`§req:consolidation-success-criteria`).
+  *(must-have)*
+- **The gate stays independently unit-testable offline.** The
+  target-gating decision remains a pure function with its own test that
+  runs under `dart test` on Linux, with no iOS SDK and no live network —
+  exactly as it does today (`§req:ci-develop-success-criteria`). Moving
+  the helper out of `hook/` does not cost the package its offline gate
+  test. *(must-have)*
+- **Future releases stay publishable.** A publish dry run is something the
+  maintainer can run (and ideally have CI run) on every release candidate,
+  so a non-publishable layout is caught before tagging rather than at the
+  moment of release. *(high)*
+
+## Publishability — user stories §req:publishable-user-stories
+
+- As a maintainer cutting a release, I want `dart pub publish` to succeed
+  on a build that already passed analysis and tests so that a green build
+  actually means "shippable."
+- As a maintainer, I want the offline target-gating test to keep running
+  unchanged after the fix so that relocating a file to satisfy pub does
+  not weaken the guarantee that non-iOS builds touch no native toolchain.
+- As a maintainer preparing a release candidate, I want to confirm the
+  package is publishable *before* tagging so that I never again discover a
+  publish blocker only after the release work is done.
+- As a developer depending on `dart_ping`, I want each released version to
+  actually be available on pub.dev so that I can upgrade.
+
+## Publishability — quality attributes §req:publishable-quality-attributes
+
+- **Maintainability / testability:** the gating decision stays a pure,
+  separately-testable function; the relocation keeps both the build hook
+  and the existing gate test importing it. No loss of offline coverage.
+- **Compatibility:** the published package behaves identically to the
+  pre-fix build for every consumer and every target — the change is a
+  source-layout move, not a behavior change. The public API and the
+  code-asset output are unchanged.
+- **Reliability (release process):** publishability is verifiable on
+  demand (dry run) and does not depend on tribal knowledge of an
+  experimental pub restriction.
+
+## Publishability — constraints §req:publishable-constraints
+
+- Native-asset hooks are an **experimental** pub feature; while
+  experimental, pub permits only recognized hook entrypoints in `hook/`
+  (today, `hook/build.dart`). Non-entrypoint Dart files must live
+  elsewhere in the package. This is a pub-tooling rule the package must
+  conform to, not change.
+- The relocated helper must remain importable by both the build hook and
+  its test. A `package:`-resolvable location (e.g. under `lib/`) is the
+  natural fit; the exact destination is a design decision deferred to
+  `/symphonize:plan`.
+- The fix must not alter the build hook's behavior or the pure-Dart gate
+  (`§req:consolidation-constraints`) and must not require the iOS
+  toolchain to run on the Linux CI host (`§req:ci-develop-constraints`).
+- This unblocks the 10.0.0 release and is release-blocking; surfaced at
+  publish time for `dart_ping` 10.0.0.
+
+## Publishability — priorities §req:publishable-priorities
+
+- **Must-have:** `dart pub publish --dry-run` passes with no disallowed-hook
+  error; `hook/` holds only permitted entrypoints; the iOS code-asset build
+  and the pure-Dart gate are unchanged; the gate stays offline
+  unit-testable.
+- **High priority:** a repeatable publish-dry-run check (ideally in CI) so
+  future releases catch a non-publishable layout before tagging.
+- **Nice-to-have:** none beyond the above — this is a focused
+  release-unblocking change.
+
+## Publishability — open decisions §req:publishable-open-decisions
+
+Surfaced during discovery and deferred to `/symphonize:plan`, where
+mechanism and feasibility are decided:
+
+- **Where the gating helper lives.** The required outcome is fixed (out of
+  `hook/`, still importable by `hook/build.dart` and its test, still
+  offline-testable); the exact destination — e.g. a file under `lib/src/`
+  imported via `package:dart_ping/…` — is a design choice. Whichever
+  location is chosen, the existing test import (`test/build_hook_gating_test.dart`)
+  is updated to match.
+- **Whether to enforce publishability in CI.** Whether the repeatable
+  publish dry run becomes a CI gate (and on which branches) or stays a
+  documented pre-release step.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2950,3 +2950,139 @@ prove the breakout is closed would be unrunnable on the Linux CI host
 (§req:host-injection-quality-attributes — testability); asserting that the
 dangerous host is refused before any command is built proves the same
 property deterministically on every runner.
+
+---
+
+# Release publishability
+
+Solution-space design for §req:publishable-*, a release-blocking fix
+discovered at publish time for `dart_ping` 10.0.0. The package builds,
+analyzes, and tests cleanly, yet `dart pub publish` aborts before
+uploading the archive with:
+
+> Hook files are experimental and `hook/gating.dart` is not allowed yet.
+
+The cause (from §req:publishable-problem-statement) is a collision between
+two correct decisions. 10.0.0 ships a native-asset **build hook**
+(`hook/build.dart`) that compiles the iOS ICMP engine into a code asset
+only for iOS targets (§spec:ios-code-asset-build-hook). Native-asset hooks
+are still an *experimental* pub feature, and while experimental, pub
+permits only the recognized hook entrypoint — `hook/build.dart` — to live
+in `hook/`; any other Dart file there is refused, and the refusal aborts
+the publish. Separately, to keep the non-negotiable pure-Dart gate
+(§spec:pure-dart-preserved) honest and offline-testable on the Linux CI
+host where the Swift/iOS cross-compile cannot run (§spec:ci,
+§spec:ci-develop, §spec:ios-tests), the target-gating decision was
+factored out of the hook into a pure function in `hook/gating.dart`. That
+helper is good engineering but is exactly the kind of non-entrypoint file
+in `hook/` the experimental rule forbids.
+
+The fix is a source-layout move, not a behavior change: relocate the
+gating helper out of `hook/` to a `package:`-resolvable location, leaving
+the build hook's behavior, the pure-Dart gate, and the offline gate test
+all intact (§req:publishable-constraints). A second, lighter capability
+makes publishability a checkable property so this class of wall is caught
+before tagging, not at release time.
+
+## Only permitted entrypoints live in `hook/` §spec:publishable-hook-layout
+*Status: not started*
+
+The published `dart_ping` package passes a publish dry run: from the
+package root, `dart pub publish --dry-run` reports no errors and, in
+particular, no "Hook files are experimental and … is not allowed yet"
+complaint, so the maintainer can publish manually
+(§req:publishable-success-criteria — passes a publish dry run;
+§req:publishable-user-stories — a green build means shippable). The
+`hook/` directory holds only the hook entrypoint(s) pub permits under the
+experimental rule — `hook/build.dart` — and no helper, support, or
+test-only Dart file (§req:publishable-success-criteria — `hook/` contains
+only permitted entrypoints; §req:publishable-constraints — pub permits
+only recognized entrypoints in `hook/`).
+
+- The target-gating decision (`shouldBuildIosAsset`) lives in a
+  `package:`-importable Dart file under `lib/` (`lib/src/build/gating.dart`,
+  imported as `package:dart_ping/src/build/gating.dart`), not in `hook/`.
+  Both the build hook (`hook/build.dart`) and its test
+  (`test/build_hook_gating_test.dart`) import it from that one location, so
+  there is a single source of truth for the gate
+  (§req:publishable-constraints — relocated helper importable by both the
+  hook and its test; §req:publishable-open-decisions — where the gating
+  helper lives).
+- The build hook's behavior is unchanged: an iOS target build still
+  compiles the in-repo native engine and emits the `dart_ping_ffi` code
+  asset, and every non-iOS target — pure-Dart desktop/server, Android, and
+  the analyzer / `dart pub get` path — still emits no code asset and
+  invokes no Swift/iOS toolchain (§req:publishable-success-criteria — the
+  iOS code-asset build still works; §spec:ios-code-asset-build-hook;
+  §spec:pure-dart-preserved — the pure-Dart gate is unchanged).
+- The gate stays an independently unit-testable pure function: its test
+  runs under `dart test` on Linux with no iOS SDK and no live network, as
+  it does today; relocating the helper does not cost the package its
+  offline gate test (§req:publishable-success-criteria — gate stays
+  offline unit-testable; §spec:ci-develop; §spec:ios-tests).
+- The published package behaves identically to the pre-fix build for every
+  consumer and every target — the public API and the code-asset output are
+  unchanged (§req:publishable-quality-attributes — compatibility).
+
+**Why relocate the helper rather than hide it from the archive:** adding
+`hook/gating.dart` to `.pubignore` so it never reaches the published
+archive is rejected — the file is not test-only scaffolding but a
+build-time dependency of `hook/build.dart`, which imports it. Omitting it
+from the archive would leave the consumer's iOS code-asset build unable to
+resolve the import at build time, trading a publish-time failure for a
+worse consume-time one. The file must ship; it just must not ship inside
+`hook/` (§req:publishable-constraints).
+
+**Why a file under `lib/` rather than inlining the gate back into the
+hook:** folding `shouldBuildIosAsset` back into `hook/build.dart` would
+satisfy the `hook/`-layout rule but forfeit the offline gate test —
+`build.dart` pulls in `package:hooks` and a `main`, and the load-bearing
+guarantee (a non-iOS or no-code-assets build never reaches the native
+toolchain) would no longer be pinned by a plain `dart test` case
+(§req:publishable-success-criteria — gate stays offline unit-testable;
+§req:publishable-quality-attributes — maintainability/testability). A
+`package:`-resolvable file under `lib/` is the natural home: the hook
+already depends on `package:code_assets` (a regular, not dev, dependency),
+which the helper imports for the `OS` type, so the relocation pulls in no
+new dependency and changes nothing for pure-Dart consumers
+(§req:publishable-open-decisions; §spec:pure-dart-preserved).
+
+## Publishability is a checkable property §spec:publish-dry-run-check
+*Status: not started*
+
+Publishability is verifiable on demand rather than resting on tribal
+knowledge of an experimental pub restriction: the maintainer can run
+`dart pub publish --dry-run` on any release candidate and get an
+unambiguous pass/fail, and that check runs in CI on the release path so a
+non-publishable layout is caught before tagging instead of at the moment
+of release (§req:publishable-success-criteria — future releases stay
+publishable; §req:publishable-priorities — high; §req:publishable-user-stories
+— confirm publishable before tagging).
+
+- The CI workflow runs `dart pub publish --dry-run` against the package
+  and fails the check when the dry run reports any error — including the
+  disallowed-hook-file error — so a regression that puts a non-entrypoint
+  file back into `hook/`, or otherwise breaks the archive, surfaces as a
+  failed required check rather than a surprise at `dart pub publish`
+  (§req:publishable-success-criteria — future releases stay publishable;
+  §spec:ci, §spec:ci-develop).
+- The dry-run check is informational about *contents* but gating about
+  *publishability*: it does not upload anything and needs no pub.dev
+  credentials, so it runs deterministically on the existing Linux CI host
+  with no iOS SDK and no network publish step
+  (§req:publishable-quality-attributes — reliability of the release
+  process).
+
+**Why gate in CI on the release path rather than leave it a documented
+step (§req:publishable-open-decisions):** the original failure cost the
+maintainer a full green build before the wall appeared at publish time. A
+documented "remember to dry-run" step has the same failure mode as the
+manual `develop`-merge gap §spec:ci-develop closed — it depends on a human
+remembering. Running the dry run as a required check on PRs into `main`
+(the `develop`→`main` release path, §spec:ci-develop) makes "green on the
+release PR" already mean "publishable," consistent with the existing CI
+philosophy of catching failures on the PR that introduced them rather than
+at the next manual milestone (§req:publishable-priorities). Gating the
+release path specifically — not every feature PR — keeps the check where a
+publishability regression actually matters while leaving the per-feature
+gate unchanged (§spec:ci-develop).

--- a/SPEC.md
+++ b/SPEC.md
@@ -2985,7 +2985,7 @@ makes publishability a checkable property so this class of wall is caught
 before tagging, not at release time.
 
 ## Only permitted entrypoints live in `hook/` §spec:publishable-hook-layout
-*Status: not started*
+*Status: implemented — the gating helper was moved out of `hook/`: `shouldBuildIosAsset` now lives in `lib/src/build/gating.dart`, importable as `package:dart_ping/src/build/gating.dart`, and both `hook/build.dart` and `test/build_hook_gating_test.dart` import it from that single location (`hook/gating.dart` deleted). `hook/` now contains only the permitted entrypoint `hook/build.dart`. The helper keeps its `package:code_assets` import (already a regular dependency), so no new dependency is added and pure-Dart consumers are unaffected. A `!lib/src/build/` negation was added to `.gitignore` so the relocated source is tracked (the generic `build/` output-ignore rule was masking it). `dart pub publish --dry-run` from the package root now reports **0 warnings** and no "Hook files are experimental … is not allowed yet" complaint; `dart analyze --fatal-infos` is clean and the offline gate test (`test/build_hook_gating_test.dart`) still passes under `dart test` on Linux with no iOS SDK / no network. Build-hook behavior and the pure-Dart gate (§spec:pure-dart-preserved) are unchanged.*
 
 The published `dart_ping` package passes a publish dry run: from the
 package root, `dart pub publish --dry-run` reports no errors and, in

--- a/SPEC.md
+++ b/SPEC.md
@@ -3048,7 +3048,21 @@ new dependency and changes nothing for pure-Dart consumers
 (§req:publishable-open-decisions; §spec:pure-dart-preserved).
 
 ## Publishability is a checkable property §spec:publish-dry-run-check
-*Status: not started*
+*Status: implemented — `.github/workflows/ci.yml` adds a `publish-dry-run` job
+that runs `dart pub publish --dry-run` on the Linux host (credential-free, no
+upload, no iOS SDK) and fails on any error the dry run reports. It is gated to
+the release path via `if: github.base_ref == 'main'`, so it runs on
+`develop`→`main` PRs but not on feature PRs into `develop` (§spec:ci-develop is
+unchanged). One workflow file, gated by target branch — single source of truth.
+Making it a required, merge-gating check is a GitHub branch-protection setting
+on `main` (outside the workflow file), the same pattern §spec:ci-develop used.
+Caveat: on the current toolchain (Dart 3.12.x, installed by `setup-dart@v1`) the
+client-side dry run no longer rejects a disallowed non-entrypoint file in
+`hook/` — it lists the file and exits 0, noting "the server may enforce
+additional checks" — so that specific restriction is now enforced server-side at
+`dart pub publish`. The dry run still catches archive/pubspec/structural publish
+errors before tagging; a deterministic `hook/`-contents guard was left out of
+scope (§spec is "run the dry run").*
 
 Publishability is verifiable on demand rather than resting on tribal
 knowledge of an experimental pub restriction: the maintainer can run

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -20,7 +20,7 @@ import 'dart:io';
 import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 
-import 'gating.dart';
+import 'package:dart_ping/src/build/gating.dart';
 
 /// The code-asset name. The Dart FFI binding (#28-2) opens this asset as
 /// `package:dart_ping/dart_ping_ffi` (i.e. `@Native(assetId: ...)` /

--- a/lib/src/build/gating.dart
+++ b/lib/src/build/gating.dart
@@ -1,11 +1,17 @@
 // Target-gating decision for the dart_ping build hook
 // (§spec:ios-code-asset-build-hook, §spec:pure-dart-preserved).
 //
-// This is factored out of `build.dart` as a pure function so the gate that
+// This is factored out of `hook/build.dart` as a pure function so the gate that
 // guarantees "non-iOS builds invoke no native toolchain" is unit-testable
 // offline (`dart test`) on the Linux CI host, where the Swift/iOS cross-compile
 // itself cannot run (§spec:ci, §spec:ios-tests). The hook calls this before
 // touching any toolchain; the test asserts the full matrix.
+//
+// It lives under `lib/` (importable as `package:dart_ping/src/build/gating.dart`)
+// rather than in `hook/` because pub's experimental native-asset-hook rule
+// permits only the recognized entrypoint `hook/build.dart` inside `hook/`; a
+// non-entrypoint helper there aborts `dart pub publish`
+// (§spec:publishable-hook-layout).
 
 import 'package:code_assets/code_assets.dart';
 

--- a/test/build_hook_gating_test.dart
+++ b/test/build_hook_gating_test.dart
@@ -12,7 +12,7 @@
 import 'package:code_assets/code_assets.dart';
 import 'package:test/test.dart';
 
-import '../hook/gating.dart';
+import 'package:dart_ping/src/build/gating.dart';
 
 void main() {
   group('shouldBuildIosAsset', () {


### PR DESCRIPTION
## Release PR — `develop` → `main`

Cuts the publishability fix to `main`. Brings everything currently on `develop` that `main` lacks (9 commits) — the release-blocking `dart_ping` publish fix plus its CI guard.

## What's included

- **`§spec:publishable-hook-layout`** — relocate the build-hook gating helper out of `hook/` (`hook/gating.dart` → `lib/src/build/gating.dart`, imported as `package:dart_ping/src/build/gating.dart`). This unblocks `dart pub publish`, which was aborting with *"Hook files are experimental and `hook/gating.dart` is not allowed yet."* `hook/` now holds only the permitted entrypoint `build.dart`. Source-layout move only — build-hook behavior, the pure-Dart gate, and the offline gate test are unchanged.
- **`§spec:publish-dry-run-check`** — a `publish-dry-run` CI job that runs `dart pub publish --dry-run` on PRs into `main` (this release path), failing on any publish error so a non-publishable layout is caught before tagging.
- Supporting REQUIREMENTS.md / SPEC.md sections (`§req:publishable-*`).

## Note on the release gate

This PR targets `main`, so the new **`publish-dry-run (release gate)`** check runs here for the first time — expect it to pass (validated locally: `dart pub publish --dry-run` → 0 warnings, no disallowed-hook error).

## Verification

- `dart analyze --fatal-infos` → clean
- `dart test -x live` → all 303 tests pass
- `dart pub publish --dry-run` → 0 warnings → **publishable**
- `lib/src/build/gating.dart` is git-tracked and present in the publish archive (the helper must ship, just not inside `hook/`).

Feature PR #98 (this work into `develop`) carries the per-section detail and the integration test path. The maintainer publishes 10.0.0 manually after this merges — nothing here publishes automatically.
